### PR TITLE
Problems: Eaton G3 ePDU outlet.%i.name overwritten by fallback entry; device.count==1 not published

### DIFF
--- a/drivers/eaton-pdu-marlin-mib.c
+++ b/drivers/eaton-pdu-marlin-mib.c
@@ -726,16 +726,9 @@ static snmp_info_t eaton_marlin_mib[] = {
 		SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK | SU_OUTLET | SU_TYPE_DAISY_1,
 		NULL, NULL },
 
-	/* Outlet physical name OID in new G3 firmware (02.00.0051)
-	 * is named outletDesignator (other MIBs outletPhysicalName)
-	 * and is a read-only string provided by firmware
-	 * outletDesignator.0.1 = Value (OctetString): "A1"
-	 * outletPhysicalName.0.16 = Value (OctetString): "A16"
-	 */
-	{ "outlet.%i.name", ST_FLAG_STRING, SU_INFOSIZE,
-		".1.3.6.1.4.1.534.6.6.7.6.1.1.6.%i.%i",
-		NULL, SU_FLAG_STATIC | SU_FLAG_UNIQUE | SU_FLAG_OK | SU_OUTLET | SU_TYPE_DAISY_1,
-		NULL, NULL },
+	/* NOTE: For daisychain devices ATM the last listed value presented by
+	 * the SNMP device is kept by the driver - no SU_FLAG_UNIQUE here yet.
+	 * Verified that a non-implemented OID does not publish empty values. */
 	/* Fallback in firmwares issued before Sep 2017 is to use the
 	 * outletID: Outlet physical name, related to its number in the group
 	 * ex: first outlet of the second group (B) is B1, or can default to
@@ -744,6 +737,16 @@ static snmp_info_t eaton_marlin_mib[] = {
 	 */
 	{ "outlet.%i.name", ST_FLAG_STRING, SU_INFOSIZE,
 		".1.3.6.1.4.1.534.6.6.7.6.1.1.2.%i.%i",
+		NULL, SU_FLAG_STATIC | SU_FLAG_UNIQUE | SU_FLAG_OK | SU_OUTLET | SU_TYPE_DAISY_1,
+		NULL, NULL },
+	/* Preferred: Outlet physical name OID in new G3 firmware (02.00.0051)
+	 * is named outletDesignator (other MIBs outletPhysicalName)
+	 * and is a read-only string provided by firmware
+	 * outletDesignator.0.1 = Value (OctetString): "A1"
+	 * outletPhysicalName.0.16 = Value (OctetString): "A16"
+	 */
+	{ "outlet.%i.name", ST_FLAG_STRING, SU_INFOSIZE,
+		".1.3.6.1.4.1.534.6.6.7.6.1.1.6.%i.%i",
 		NULL, SU_FLAG_STATIC | SU_FLAG_UNIQUE | SU_FLAG_OK | SU_OUTLET | SU_TYPE_DAISY_1,
 		NULL, NULL },
 

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -2147,24 +2147,15 @@ bool_t daisychain_init()
 		}
 
 		/* Sanity check before data publication */
-/* FIXME: Should this check be in place? Or is a single device able to grow
- * with more chained devices on the fly (without driver re-init)? */
-/*
- *		if (devices_count == 1) {
- *			daisychain_enabled = FALSE;
- *			upsdebugx(1, "Devices count is exactly 1, disabling daisychain support!");
- *		}
- */
 
 		if (devices_count < 1) {
 			devices_count = 1;
 			daisychain_enabled = FALSE;
 			upsdebugx(1, "Devices count is less than 1!");
 			upsdebugx(1, "Falling back to 1 device and disabling daisychain support!");
-		}
-
-		/* Publish the device(s) count */
-		if (devices_count > 1) {
+		} else {
+			/* Publish the device(s) count - even if just one
+			 * device was recognized at this moment */
 			dstate_setinfo("device.count", "%ld", devices_count);
 
 			/* Also publish the default value for mfr and a forged model

--- a/scripts/DMF/dmfsnmp/eaton-pdu-marlin-mib.dmf
+++ b/scripts/DMF/dmfsnmp/eaton-pdu-marlin-mib.dmf
@@ -249,8 +249,8 @@
 		<snmp_info flag_ok="yes" multiplier="128.0" name="outlet.%i.desc" oid=".1.3.6.1.4.1.534.6.6.7.6.1.1.3.%i.%i" outlet="yes" semistatic="yes" string="yes" type_daisy="1" writable="yes"/>
 		<snmp_info flag_ok="yes" lookup="marlin_outlet_status_info" multiplier="128.0" name="outlet.%i.status" oid=".1.3.6.1.4.1.534.6.6.7.6.6.1.2.%i.%i" outlet="yes" string="yes" type_daisy="1"/>
 		<snmp_info absent="yes" default="%i" flag_ok="yes" multiplier="1.0" name="outlet.%i.id" outlet="yes" static="yes" type_daisy="1"/>
-		<snmp_info flag_ok="yes" multiplier="128.0" name="outlet.%i.name" oid=".1.3.6.1.4.1.534.6.6.7.6.1.1.6.%i.%i" outlet="yes" static="yes" string="yes" type_daisy="1" unique="yes"/>
 		<snmp_info flag_ok="yes" multiplier="128.0" name="outlet.%i.name" oid=".1.3.6.1.4.1.534.6.6.7.6.1.1.2.%i.%i" outlet="yes" static="yes" string="yes" type_daisy="1" unique="yes"/>
+		<snmp_info flag_ok="yes" multiplier="128.0" name="outlet.%i.name" oid=".1.3.6.1.4.1.534.6.6.7.6.1.1.6.%i.%i" outlet="yes" static="yes" string="yes" type_daisy="1" unique="yes"/>
 		<snmp_info multiplier="128.0" name="outlet.%i.groupid" oid=".1.3.6.1.4.1.534.6.6.7.6.2.1.3.%i.%i.1" outlet="yes" static="yes" string="yes" type_daisy="1" unique="yes"/>
 		<snmp_info multiplier="128.0" name="outlet.%i.groupid" oid=".1.3.6.1.4.1.534.6.6.7.6.2.1.3.%i.%i.2" outlet="yes" static="yes" string="yes" type_daisy="1" unique="yes"/>
 		<snmp_info multiplier="128.0" name="outlet.%i.groupid" oid=".1.3.6.1.4.1.534.6.6.7.6.2.1.3.%i.%i.3" outlet="yes" static="yes" string="yes" type_daisy="1" unique="yes"/>


### PR DESCRIPTION
Solution: shuffle the order in MIB file. Publish the value.