### PR TITLE
eaton-pdu-marlin-mib.c/dmf: add outlet timers

### DIFF
--- a/drivers/eaton-pdu-marlin-mib.c
+++ b/drivers/eaton-pdu-marlin-mib.c
@@ -1054,6 +1054,17 @@ static snmp_info_t eaton_marlin_mib[] = {
 		".1.3.6.1.4.1.534.6.6.7.6.6.1.7.%i.%i",
 		NULL, SU_FLAG_NEGINVALID | SU_OUTLET | SU_TYPE_DAISY_1, NULL, NULL },
 
+	/* Per-outlet shutdown / startup timers
+	 * outletControlOffCmd.0.1 = INTEGER: -1
+	 * outletControlOnCmd.0.1 = INTEGER: -1
+	 */
+	{ "outlet.%i.timer.shutdown", 0, 1,
+		".1.3.6.1.4.1.534.6.6.7.6.6.1.3.%i.%i",
+		NULL, SU_OUTLET | SU_TYPE_DAISY_1, NULL, NULL },
+	{ "outlet.%i.timer.start", 0, 1,
+		".1.3.6.1.4.1.534.6.6.7.6.6.1.4.%i.%i",
+		NULL, SU_OUTLET | SU_TYPE_DAISY_1, NULL, NULL },
+
 	/* TODO: handle delays
 	 * 0-n :Time in seconds until the group command is issued
 	 * -1:Cancel a pending group-level Off/On/Reboot command */

--- a/scripts/DMF/dmfsnmp/eaton-pdu-marlin-mib.dmf
+++ b/scripts/DMF/dmfsnmp/eaton-pdu-marlin-mib.dmf
@@ -309,6 +309,8 @@
 		<snmp_info command="yes" multiplier="0.0" name="outlet.%i.load.cycle" oid=".1.3.6.1.4.1.534.6.6.7.6.6.1.5.%i.%i" outlet="yes" type_daisy="1"/>
 		<snmp_info multiplier="1.0" name="outlet.%i.delay.shutdown" oid=".1.3.6.1.4.1.534.6.6.7.6.6.1.10.%i.%i" outlet="yes" positive="yes" type_daisy="1" writable="yes"/>
 		<snmp_info multiplier="1.0" name="outlet.%i.delay.start" oid=".1.3.6.1.4.1.534.6.6.7.6.6.1.7.%i.%i" outlet="yes" positive="yes" type_daisy="1" writable="yes"/>
+		<snmp_info multiplier="1.0" name="outlet.%i.timer.shutdown" oid=".1.3.6.1.4.1.534.6.6.7.6.6.1.3.%i.%i" outlet="yes" type_daisy="1"/>
+		<snmp_info multiplier="1.0" name="outlet.%i.timer.start" oid=".1.3.6.1.4.1.534.6.6.7.6.6.1.4.%i.%i" outlet="yes" type_daisy="1"/>
 		<snmp_info command="yes" multiplier="0.0" name="outlet.group.%i.load.off" oid=".1.3.6.1.4.1.534.6.6.7.5.6.1.3.%i.%i" outlet_group="yes" type_daisy="1"/>
 		<snmp_info command="yes" multiplier="0.0" name="outlet.group.%i.load.on" oid=".1.3.6.1.4.1.534.6.6.7.5.6.1.4.%i.%i" outlet_group="yes" type_daisy="1"/>
 		<snmp_info command="yes" multiplier="0.0" name="outlet.group.%i.load.cycle" oid=".1.3.6.1.4.1.534.6.6.7.5.6.1.5.%i.%i" outlet_group="yes" type_daisy="1"/>


### PR DESCRIPTION
Add support for shutdown and start timers

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>