### PR TITLE
[DO NOT MERGE] Fix the Debian package generation

### DIFF
--- a/tools/nut-scanner/nut-scan.h
+++ b/tools/nut-scanner/nut-scan.h
@@ -115,6 +115,7 @@ nutscan_device_t *  nutscan_scan_ipmi(const char * startIP, const char * stopIP,
 nutscan_device_t * nutscan_scan_eaton_serial(const char* ports_list);
 
 #ifdef HAVE_PTHREAD
+extern sem_t semaphore;
 sem_t * nutscan_semaphore();
 #endif
 

--- a/tools/nut-scanner/nut-scanner.c
+++ b/tools/nut-scanner/nut-scanner.c
@@ -126,11 +126,6 @@ static char * serial_ports = NULL;
 
 #ifdef HAVE_PTHREAD
 static pthread_t thread[TYPE_END];
-sem_t semaphore;
-
-sem_t * nutscan_semaphore() {
-    return &semaphore;
-}
 
 static void * run_usb(void * arg)
 {

--- a/tools/nut-scanner/nutscan-device.c
+++ b/tools/nut-scanner/nutscan-device.c
@@ -21,10 +21,15 @@
     \author Frederic Bohe <fredericbohe@eaton.com>
 */
 
+#include "common.h"
 #include "nutscan-device.h"
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+
+#ifdef HAVE_PTHREAD
+#include <semaphore.h>
+#endif
 
 const char * nutscan_device_type_strings[TYPE_END - 1] = {
 	"USB",
@@ -35,6 +40,16 @@ const char * nutscan_device_type_strings[TYPE_END - 1] = {
 	"Avahi",
 	"serial",
 	};
+
+#ifdef HAVE_PTHREAD
+/* FIXME: A more suitable implementation would be to have a generic nutscan.c
+ * file, but this would just contain the semaphore and its function! */
+sem_t semaphore;
+
+sem_t * nutscan_semaphore() {
+    return &semaphore;
+}
+#endif
 
 nutscan_device_t * nutscan_new_device()
 {


### PR DESCRIPTION
Some compilation flags prevent from building nut-scanner on Debian. A more
suitable implementation would be to have a generic nutscan.c file, but this
would just contain the semaphore and its function

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>