### PR TITLE
Add support for dry contacts to Eaton ATS16 and UPS

### DIFF
--- a/drivers/eaton-ats16-mib.c
+++ b/drivers/eaton-ats16-mib.c
@@ -24,7 +24,7 @@
 
 #include "eaton-ats16-mib.h"
 
-#define EATON_ATS16_MIB_VERSION  "0.14"
+#define EATON_ATS16_MIB_VERSION  "0.15"
 
 #define EATON_ATS16_SYSOID       ".1.3.6.1.4.1.534.10"
 #define EATON_ATS16_MODEL        ".1.3.6.1.4.1.534.10.2.1.2.0"
@@ -74,6 +74,15 @@ static info_lkp_t eaton_ats16_test_result_info[] = {
 static info_lkp_t eaton_ats16_output_status_info[] = {
 	{ 1, "OFF" }, /* Output not powered */
 	{ 2, "OL" },  /* Output powered */
+	{ 0, NULL }
+};
+
+static info_lkp_t eaton_ats16_ambient_drycontacts_info[] = {
+	{ -1, "unknown" },
+	{ 1, "open" },
+	{ 2, "closed" },
+	{ 3, "open" },   /* openWithNotice   */
+	{ 4, "closed" }, /* closedWithNotice */
 	{ 0, NULL }
 };
 
@@ -160,6 +169,15 @@ static snmp_info_t eaton_ats16_mib[] = {
 	{ "ambient.humidity.low", ST_FLAG_RW, 1, ".1.3.6.1.4.1.534.10.2.5.7.0", NULL, SU_FLAG_OK, NULL, NULL },
 	/* ats2EnvRemoteHumidityUpperLimit.0 = INTEGER: 90 percent */
 	{ "ambient.humidity.high", ST_FLAG_RW, 1, ".1.3.6.1.4.1.534.10.2.5.8.0", NULL, SU_FLAG_OK, NULL, NULL },
+	/* Dry contacts on EMP001 TH module */
+	/* ats2ContactState.1 = INTEGER: open(1) */
+	{ "ambient.contacts.1.status", ST_FLAG_STRING, SU_INFOSIZE,
+		".1.3.6.1.4.1.534.10.2.5.4.1.3.1",
+		NULL, SU_FLAG_OK, &eaton_ats16_ambient_drycontacts_info[0], NULL },
+	/* ats2ContactState.2 = INTEGER: open(1) */
+	{ "ambient.contacts.2.status", ST_FLAG_STRING, SU_INFOSIZE,
+		".1.3.6.1.4.1.534.10.2.5.4.1.3.2",
+		NULL, SU_FLAG_OK, &eaton_ats16_ambient_drycontacts_info[0], NULL },
 
 #if 0 /* FIXME: Remaining data to be processed */
 	/* ats2InputStatusDephasing.0 = INTEGER: normal(1) */
@@ -229,10 +247,6 @@ static snmp_info_t eaton_ats16_mib[] = {
 	{ "unmapped.ats2ContactType", 0, 1, ".1.3.6.1.4.1.534.10.2.5.4.1.2.1", NULL, SU_FLAG_OK, NULL, NULL },
 	/* ats2ContactType.2 = INTEGER: notUsed(4) */
 	{ "unmapped.ats2ContactType", 0, 1, ".1.3.6.1.4.1.534.10.2.5.4.1.2.2", NULL, SU_FLAG_OK, NULL, NULL },
-	/* ats2ContactState.1 = INTEGER: open(1) */
-	{ "unmapped.ats2ContactState", 0, 1, ".1.3.6.1.4.1.534.10.2.5.4.1.3.1", NULL, SU_FLAG_OK, NULL, NULL },
-	/* ats2ContactState.2 = INTEGER: open(1) */
-	{ "unmapped.ats2ContactState", 0, 1, ".1.3.6.1.4.1.534.10.2.5.4.1.3.2", NULL, SU_FLAG_OK, NULL, NULL },
 	/* ats2ContactDescr.1 = STRING: Input #1 */
 	{ "unmapped.ats2ContactDescr", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.534.10.2.5.4.1.4.1", NULL, SU_FLAG_OK, NULL, NULL },
 	/* ats2ContactDescr.2 = STRING: Input #2 */

--- a/drivers/mge-mib.c
+++ b/drivers/mge-mib.c
@@ -27,7 +27,7 @@
 
 #include "mge-mib.h"
 
-#define MGE_MIB_VERSION	"0.51"
+#define MGE_MIB_VERSION	"0.52"
 
 /* TODO:
  * - MGE PDU MIB and sysOID (".1.3.6.1.4.1.705.2") */
@@ -133,6 +133,13 @@ static info_lkp_t mge_power_source_info[] = {
 	{ 5, "OB" /* battery */ },
 	{ 6, "BOOST" /* booster */ },
 	{ 7, "TRIM" /* reducer */ },
+	{ 0, NULL }
+};
+
+static info_lkp_t mge_ambient_drycontacts_info[] = {
+	{ -1, "unknown" },
+	{ 1, "closed" },
+	{ 2, "open" },
 	{ 0, NULL }
 };
 
@@ -245,6 +252,10 @@ static snmp_info_t mge_mib[] = {
 	/* Ambient page: Environment Sensor (ref 66 846) */
 	{ "ambient.temperature", 0, 0.1, ".1.3.6.1.4.1.705.1.8.1.0", "", SU_TYPE_INT | SU_FLAG_OK, NULL },
 	{ "ambient.humidity", 0, 0.1, ".1.3.6.1.4.1.705.1.8.2.0", "", SU_TYPE_INT | SU_FLAG_OK, NULL },
+	/* upsmgEnvironmentInput1State.1 */
+	{ "ambient.contacts.1.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.705.1.8.7.1.9.1", "", SU_TYPE_INT | SU_FLAG_OK, mge_ambient_drycontacts_info },
+	/* upsmgEnvironmentInput1State.1 */
+	{ "ambient.contacts.2.status", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.705.1.8.7.1.10.1", "", SU_TYPE_INT | SU_FLAG_OK, mge_ambient_drycontacts_info },
 
 	/* Outlet page */
 	{ "outlet.id", 0, 1, NULL, "0", SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_OK, NULL },

--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -2,7 +2,7 @@
 
    Copyright (C)
 	2008-2009	Arjen de Korte <adkorte-guest@alioth.debian.org>
-	2009		Arnaud Quette <ArnaudQuette@Eaton.com>
+	2009-2017	Arnaud Quette <ArnaudQuette@Eaton.com>
 	2017		Jim Klimov <EvgenyKlimov@Eaton.com>
 
    This program is free software; you can redistribute it and/or modify
@@ -33,7 +33,7 @@
 #include "mge-xml.h"
 #include "main.h" /* for testvar() */
 
-#define MGE_XML_VERSION		"MGEXML/0.28"
+#define MGE_XML_VERSION		"MGEXML/0.29"
 
 #define MGE_XML_INITUPS		"/"
 #define MGE_XML_INITINFO	"/mgeups/product.xml /product.xml /ws/product.xml"
@@ -575,6 +575,27 @@ static const char *mge_ambient_info(const char *val)
 	}
 }
 
+static const char *mge_drycontact_info(const char *val)
+{
+	/* these values should theoretically be obtained through
+	 * Environment.Input[1].State[x].Description
+	 * Examples:
+	 * <OBJECT name="Environment.Input[1].State[0].Description">open</OBJECT>
+	 * <OBJECT name="Environment.Input[1].State[1].Description">closed</OBJECT>
+	 */
+	switch (atoi(val))
+	{
+	case 0:
+		return "open";
+	case 1:
+		return "closed";
+	default:
+		return NULL;
+	}
+}
+
+
+
 static const char *mge_timer_shutdown(const char *delay_before_shutoff)
 {
 	if (atoi(delay_before_shutoff) > -1 ) {
@@ -1059,6 +1080,8 @@ static xml_info_t mge_xml2nut[] = {
 	{ "ambient.temperature.low", ST_FLAG_RW, 0, "Environment.Temperature.LowThreshold", 0, 0, NULL },
 	{ "ambient.temperature.maximum", 0, 0, "Environment.PresentStatus.HighTemperature", 0, 0, mge_ambient_info },
 	{ "ambient.temperature.minimum", 0, 0, "Environment.PresentStatus.LowTemperature", 0, 0, mge_ambient_info },
+	{ "ambient.contacts.1.status", 0, 0, "Environment.Input[1].PresentStatus.State", 0, 0, mge_drycontact_info },
+	{ "ambient.contacts.2.status", 0, 0, "Environment.Input[2].PresentStatus.State", 0, 0, mge_drycontact_info },
 
 	/* Outlet page (using MGE UPS SYSTEMS - PowerShare technology) */
 	{ "outlet.id", 0, 0, "UPS.OutletSystem.Outlet[1].OutletID", 0, 0, NULL },

--- a/drivers/powerware-mib.c
+++ b/drivers/powerware-mib.c
@@ -25,7 +25,7 @@
 
 #include "powerware-mib.h"
 
-#define PW_MIB_VERSION "0.90"
+#define PW_MIB_VERSION "0.91"
 
 /* TODO: more sysOID and MIBs support:
  * 
@@ -194,6 +194,15 @@ static info_lkp_t pw_yes_no_info[] = {
 	{ 0, NULL }
 };
 
+static info_lkp_t pw_ambient_drycontacts_info[] = {
+	{ -1, "unknown" },
+	{ 1, "open" },
+	{ 2, "closed" },
+	{ 3, "open" },   /* openWithNotice   */
+	{ 4, "closed" }, /* closedWithNotice */
+	{ 0, NULL }
+};
+
 /* Snmp2NUT lookup table */
 
 static snmp_info_t pw_mib[] = {
@@ -358,6 +367,12 @@ static snmp_info_t pw_mib[] = {
 	{ "ambient.humidity.low", ST_FLAG_RW, 1.0, "1.3.6.1.4.1.534.1.6.11.0", "", 0, NULL },
 	/* XUPS-MIB::xupsEnvRemoteHumidityUpperLimit.0 */
 	{ "ambient.humidity.high", ST_FLAG_RW, 1.0, "1.3.6.1.4.1.534.1.6.12.0", "", 0, NULL },
+	/* XUPS-MIB::xupsContactState.1 */
+	{ "ambient.contacts.1.status", ST_FLAG_STRING, SU_INFOSIZE,
+		".1.3.6.1.4.1.534.1.6.8.1.3.1", "", 0, &pw_ambient_drycontacts_info[0] },
+	/* XUPS-MIB::xupsContactState.2 */
+	{ "ambient.contacts.2.status", ST_FLAG_STRING, SU_INFOSIZE,
+		".1.3.6.1.4.1.534.1.6.8.1.3.2", "", 0, &pw_ambient_drycontacts_info[0] },
 
 	/* instant commands */
 	{ "test.battery.start.quick", 0, 1, PW_OID_BATTEST_START, "",

--- a/scripts/DMF/dmfsnmp/eaton-ats16-mib.dmf
+++ b/scripts/DMF/dmfsnmp/eaton-ats16-mib.dmf
@@ -28,6 +28,13 @@
 		<lookup_info oid="2" value="high"/>
 		<lookup_info oid="3" value="low"/>
 	</lookup>
+	<lookup name="eaton_ats16_ambient_drycontacts_info">
+		<lookup_info oid="-1" value="unknown"/>
+		<lookup_info oid="1" value="open"/>
+		<lookup_info oid="2" value="closed"/>
+		<lookup_info oid="3" value="open"/>
+		<lookup_info oid="4" value="closed"/>
+	</lookup>
 	<lookup name="eaton_ats16_output_status_info">
 		<lookup_info oid="1" value="OFF"/>
 		<lookup_info oid="2" value="OL"/>
@@ -69,7 +76,9 @@
 		<snmp_info flag_ok="yes" multiplier="0.1" name="ambient.humidity" oid=".1.3.6.1.4.1.534.10.2.5.2.0"/>
 		<snmp_info flag_ok="yes" multiplier="1.0" name="ambient.humidity.low" oid=".1.3.6.1.4.1.534.10.2.5.7.0" writable="yes"/>
 		<snmp_info flag_ok="yes" multiplier="1.0" name="ambient.humidity.high" oid=".1.3.6.1.4.1.534.10.2.5.8.0" writable="yes"/>
+		<snmp_info flag_ok="yes" lookup="eaton_ats16_ambient_drycontacts_info" multiplier="128.0" name="ambient.contacts.1.status" oid=".1.3.6.1.4.1.534.10.2.5.4.1.3.1" string="yes"/>
+		<snmp_info flag_ok="yes" lookup="eaton_ats16_ambient_drycontacts_info" multiplier="128.0" name="ambient.contacts.2.status" oid=".1.3.6.1.4.1.534.10.2.5.4.1.3.2" string="yes"/>
 	</snmp>
-	<mib2nut auto_check=".1.3.6.1.4.1.534.10.2.1.2.0" mib_name="eaton_ats16" name="eaton_ats16" oid=".1.3.6.1.4.1.705.1" snmp_info="eaton_ats16_mib" version="0.14"/>
+	<mib2nut auto_check=".1.3.6.1.4.1.534.10.2.1.2.0" mib_name="eaton_ats16" name="eaton_ats16" oid=".1.3.6.1.4.1.705.1" snmp_info="eaton_ats16_mib" version="0.15"/>
 </nut>
 

--- a/scripts/DMF/dmfsnmp/mge-mib.dmf
+++ b/scripts/DMF/dmfsnmp/mge-mib.dmf
@@ -46,6 +46,11 @@
 		<lookup_info oid="1" value="BYPASS"/>
 		<lookup_info oid="2" value=""/>
 	</lookup>
+	<lookup name="mge_ambient_drycontacts_info">
+		<lookup_info oid="-1" value="unknown"/>
+		<lookup_info oid="1" value="closed"/>
+		<lookup_info oid="2" value="open"/>
+	</lookup>
 	<lookup name="mge_beeper_status_info">
 		<lookup_info oid="1" value="disabled"/>
 		<lookup_info oid="2" value="enabled"/>
@@ -133,6 +138,8 @@
 		<snmp_info default="" flag_ok="yes" multiplier="0.1" name="battery.voltage" oid=".1.3.6.1.4.1.705.1.5.5.0"/>
 		<snmp_info default="" flag_ok="yes" multiplier="0.1" name="ambient.temperature" oid=".1.3.6.1.4.1.705.1.8.1.0" power_status="yes"/>
 		<snmp_info default="" flag_ok="yes" multiplier="0.1" name="ambient.humidity" oid=".1.3.6.1.4.1.705.1.8.2.0" power_status="yes"/>
+		<snmp_info default="" flag_ok="yes" lookup="mge_ambient_drycontacts_info" multiplier="128.0" name="ambient.contacts.1.status" oid=".1.3.6.1.4.1.705.1.8.7.1.9.1" power_status="yes" string="yes"/>
+		<snmp_info default="" flag_ok="yes" lookup="mge_ambient_drycontacts_info" multiplier="128.0" name="ambient.contacts.2.status" oid=".1.3.6.1.4.1.705.1.8.7.1.10.1" power_status="yes" string="yes"/>
 		<snmp_info absent="yes" default="0" flag_ok="yes" multiplier="1.0" name="outlet.id" static="yes"/>
 		<snmp_info absent="yes" default="Main Outlet" flag_ok="yes" multiplier="20.0" name="outlet.desc" static="yes" string="yes" writable="yes"/>
 		<snmp_info command="yes" default="" flag_ok="yes" multiplier="2.0" name="test.battery.start" oid=".1.3.6.1.4.1.705.1.10.4.0"/>
@@ -142,6 +149,6 @@
 		<snmp_info command="yes" default="" multiplier="20.0" name="load.off.delay" oid="1.3.6.1.2.1.33.1.8.2.0"/>
 		<snmp_info command="yes" default="" multiplier="30.0" name="load.on.delay" oid="1.3.6.1.2.1.33.1.8.3.0"/>
 	</snmp>
-	<mib2nut auto_check=".1.3.6.1.4.1.705.1.1.1.0" mib_name="mge" name="mge" oid=".1.3.6.1.4.1.705.1" snmp_info="mge_mib" version="0.51"/>
+	<mib2nut auto_check=".1.3.6.1.4.1.705.1.1.1.0" mib_name="mge" name="mge" oid=".1.3.6.1.4.1.705.1" snmp_info="mge_mib" version="0.52"/>
 </nut>
 

--- a/scripts/DMF/dmfsnmp/powerware-mib.dmf
+++ b/scripts/DMF/dmfsnmp/powerware-mib.dmf
@@ -27,6 +27,13 @@
 		<lookup_info oid="1" value="yes"/>
 		<lookup_info oid="2" value="no"/>
 	</lookup>
+	<lookup name="pw_ambient_drycontacts_info">
+		<lookup_info oid="-1" value="unknown"/>
+		<lookup_info oid="1" value="open"/>
+		<lookup_info oid="2" value="closed"/>
+		<lookup_info oid="3" value="open"/>
+		<lookup_info oid="4" value="closed"/>
+	</lookup>
 	<lookup name="pw_batt_test_info">
 		<lookup_info oid="1" value="Unknown"/>
 		<lookup_info oid="2" value="Done and passed"/>
@@ -181,6 +188,8 @@
 		<snmp_info default="" multiplier="1.0" name="ambient.humidity" oid="1.3.6.1.4.1.534.1.6.6.0" power_status="yes"/>
 		<snmp_info default="" multiplier="1.0" name="ambient.humidity.low" oid="1.3.6.1.4.1.534.1.6.11.0" power_status="yes" writable="yes"/>
 		<snmp_info default="" multiplier="1.0" name="ambient.humidity.high" oid="1.3.6.1.4.1.534.1.6.12.0" power_status="yes" writable="yes"/>
+		<snmp_info default="" lookup="pw_ambient_drycontacts_info" multiplier="128.0" name="ambient.contacts.1.status" oid=".1.3.6.1.4.1.534.1.6.8.1.3.1" power_status="yes" string="yes"/>
+		<snmp_info default="" lookup="pw_ambient_drycontacts_info" multiplier="128.0" name="ambient.contacts.2.status" oid=".1.3.6.1.4.1.534.1.6.8.1.3.2" power_status="yes" string="yes"/>
 		<snmp_info command="yes" default="" flag_ok="yes" multiplier="1.0" name="test.battery.start.quick" oid="1.3.6.1.4.1.534.1.8.1"/>
 		<snmp_info command="yes" default="" flag_ok="yes" multiplier="0.0" name="shutdown.return" oid="1.3.6.1.4.1.534.1.9.6"/>
 		<snmp_info command="yes" default="" flag_ok="yes" multiplier="0.0" name="shutdown.stop" oid="1.3.6.1.4.1.534.1.9.1"/>
@@ -190,7 +199,7 @@
 		<snmp_info command="yes" default="" flag_ok="yes" multiplier="20.0" name="load.on.delay" oid="1.3.6.1.4.1.534.1.9.2"/>
 		<snmp_info default="" multiplier="1.0" name="ups.alarms" oid="1.3.6.1.4.1.534.1.7.1.0" power_status="yes"/>
 	</snmp>
-	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pw" name="powerware" oid=".1.3.6.1.4.1.534.1" snmp_info="pw_mib" version="0.90"/>
-	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pxgx_ups" name="pxgx_ups" oid=".1.3.6.1.4.1.534.2.12" snmp_info="pw_mib" version="0.90"/>
+	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pw" name="powerware" oid=".1.3.6.1.4.1.534.1" snmp_info="pw_mib" version="0.91"/>
+	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pxgx_ups" name="pxgx_ups" oid=".1.3.6.1.4.1.534.2.12" snmp_info="pw_mib" version="0.91"/>
 </nut>
 


### PR DESCRIPTION
Add support for the 2 GPI accessible through EMP001 environmental sensor,
connected to a UPS or ATS16. The same is already available for Eaton ePDU.
This affect the snmp-ups driver (eaton_ats16 and pw/pxgx_ups MIBs), and the
netxml-ups driver

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>