### PR TITLE
Modify "open" to "opened" for dry contacts status

### DIFF
--- a/drivers/eaton-ats16-mib.c
+++ b/drivers/eaton-ats16-mib.c
@@ -24,7 +24,7 @@
 
 #include "eaton-ats16-mib.h"
 
-#define EATON_ATS16_MIB_VERSION  "0.15"
+#define EATON_ATS16_MIB_VERSION  "0.16"
 
 #define EATON_ATS16_SYSOID       ".1.3.6.1.4.1.534.10"
 #define EATON_ATS16_MODEL        ".1.3.6.1.4.1.534.10.2.1.2.0"
@@ -79,9 +79,9 @@ static info_lkp_t eaton_ats16_output_status_info[] = {
 
 static info_lkp_t eaton_ats16_ambient_drycontacts_info[] = {
 	{ -1, "unknown" },
-	{ 1, "open" },
+	{ 1, "opened" },
 	{ 2, "closed" },
-	{ 3, "open" },   /* openWithNotice   */
+	{ 3, "opened" },   /* openWithNotice   */
 	{ 4, "closed" }, /* closedWithNotice */
 	{ 0, NULL }
 };

--- a/drivers/eaton-pdu-marlin-mib.c
+++ b/drivers/eaton-pdu-marlin-mib.c
@@ -36,7 +36,7 @@
 /* Eaton PDU-MIB - Marlin MIB
  * ************************** */
 
-#define EATON_MARLIN_MIB_VERSION	"0.45"
+#define EATON_MARLIN_MIB_VERSION	"0.46"
 #define EATON_MARLIN_SYSOID			".1.3.6.1.4.1.534.6.6.7"
 #define EATON_MARLIN_OID_MODEL_NAME	".1.3.6.1.4.1.534.6.6.7.1.2.1.2.0"
 
@@ -110,7 +110,7 @@ static info_lkp_t marlin_threshold_frequency_status_info[] = {
 
 static info_lkp_t marlin_ambient_drycontacts_info[] = {
 	{ -1, "unknown" },
-	{ 0, "open" },
+	{ 0, "opened" },
 	{ 1, "closed" },
 	{ 0, NULL }
 };

--- a/drivers/mge-mib.c
+++ b/drivers/mge-mib.c
@@ -27,7 +27,7 @@
 
 #include "mge-mib.h"
 
-#define MGE_MIB_VERSION	"0.52"
+#define MGE_MIB_VERSION	"0.53"
 
 /* TODO:
  * - MGE PDU MIB and sysOID (".1.3.6.1.4.1.705.2") */
@@ -139,7 +139,7 @@ static info_lkp_t mge_power_source_info[] = {
 static info_lkp_t mge_ambient_drycontacts_info[] = {
 	{ -1, "unknown" },
 	{ 1, "closed" },
-	{ 2, "open" },
+	{ 2, "opened" },
 	{ 0, NULL }
 };
 

--- a/drivers/mge-xml.c
+++ b/drivers/mge-xml.c
@@ -33,7 +33,7 @@
 #include "mge-xml.h"
 #include "main.h" /* for testvar() */
 
-#define MGE_XML_VERSION		"MGEXML/0.29"
+#define MGE_XML_VERSION		"MGEXML/0.30"
 
 #define MGE_XML_INITUPS		"/"
 #define MGE_XML_INITINFO	"/mgeups/product.xml /product.xml /ws/product.xml"
@@ -586,7 +586,7 @@ static const char *mge_drycontact_info(const char *val)
 	switch (atoi(val))
 	{
 	case 0:
-		return "open";
+		return "opened";
 	case 1:
 		return "closed";
 	default:

--- a/drivers/powerware-mib.c
+++ b/drivers/powerware-mib.c
@@ -25,7 +25,7 @@
 
 #include "powerware-mib.h"
 
-#define PW_MIB_VERSION "0.91"
+#define PW_MIB_VERSION "0.92"
 
 /* TODO: more sysOID and MIBs support:
  * 
@@ -196,9 +196,9 @@ static info_lkp_t pw_yes_no_info[] = {
 
 static info_lkp_t pw_ambient_drycontacts_info[] = {
 	{ -1, "unknown" },
-	{ 1, "open" },
+	{ 1, "opened" },
 	{ 2, "closed" },
-	{ 3, "open" },   /* openWithNotice   */
+	{ 3, "opened" },   /* openWithNotice   */
 	{ 4, "closed" }, /* closedWithNotice */
 	{ 0, NULL }
 };

--- a/scripts/DMF/dmfsnmp/eaton-ats16-mib.dmf
+++ b/scripts/DMF/dmfsnmp/eaton-ats16-mib.dmf
@@ -30,9 +30,9 @@
 	</lookup>
 	<lookup name="eaton_ats16_ambient_drycontacts_info">
 		<lookup_info oid="-1" value="unknown"/>
-		<lookup_info oid="1" value="open"/>
+		<lookup_info oid="1" value="opened"/>
 		<lookup_info oid="2" value="closed"/>
-		<lookup_info oid="3" value="open"/>
+		<lookup_info oid="3" value="opened"/>
 		<lookup_info oid="4" value="closed"/>
 	</lookup>
 	<lookup name="eaton_ats16_output_status_info">
@@ -79,6 +79,6 @@
 		<snmp_info flag_ok="yes" lookup="eaton_ats16_ambient_drycontacts_info" multiplier="128.0" name="ambient.contacts.1.status" oid=".1.3.6.1.4.1.534.10.2.5.4.1.3.1" string="yes"/>
 		<snmp_info flag_ok="yes" lookup="eaton_ats16_ambient_drycontacts_info" multiplier="128.0" name="ambient.contacts.2.status" oid=".1.3.6.1.4.1.534.10.2.5.4.1.3.2" string="yes"/>
 	</snmp>
-	<mib2nut auto_check=".1.3.6.1.4.1.534.10.2.1.2.0" mib_name="eaton_ats16" name="eaton_ats16" oid=".1.3.6.1.4.1.705.1" snmp_info="eaton_ats16_mib" version="0.15"/>
+	<mib2nut auto_check=".1.3.6.1.4.1.534.10.2.1.2.0" mib_name="eaton_ats16" name="eaton_ats16" oid=".1.3.6.1.4.1.705.1" snmp_info="eaton_ats16_mib" version="0.16"/>
 </nut>
 

--- a/scripts/DMF/dmfsnmp/eaton-pdu-marlin-mib.dmf
+++ b/scripts/DMF/dmfsnmp/eaton-pdu-marlin-mib.dmf
@@ -28,7 +28,7 @@
 	</lookup>
 	<lookup name="marlin_ambient_drycontacts_info">
 		<lookup_info oid="-1" value="unknown"/>
-		<lookup_info oid="0" value="open"/>
+		<lookup_info oid="0" value="opened"/>
 		<lookup_info oid="1" value="closed"/>
 	</lookup>
 	<lookup name="marlin_outlet_type_info">
@@ -305,6 +305,6 @@
 		<snmp_info command="yes" multiplier="0.0" name="outlet.group.%i.load.on" oid=".1.3.6.1.4.1.534.6.6.7.5.6.1.4.%i.%i" outlet_group="yes" type_daisy="1"/>
 		<snmp_info command="yes" multiplier="0.0" name="outlet.group.%i.load.cycle" oid=".1.3.6.1.4.1.534.6.6.7.5.6.1.5.%i.%i" outlet_group="yes" type_daisy="1"/>
 	</snmp>
-	<mib2nut auto_check=".1.3.6.1.4.1.534.6.6.7.1.2.1.2.0" mib_name="eaton_epdu" name="eaton_marlin" oid=".1.3.6.1.4.1.534.6.6.7" snmp_info="eaton_marlin_mib" version="0.45"/>
+	<mib2nut auto_check=".1.3.6.1.4.1.534.6.6.7.1.2.1.2.0" mib_name="eaton_epdu" name="eaton_marlin" oid=".1.3.6.1.4.1.534.6.6.7" snmp_info="eaton_marlin_mib" version="0.46"/>
 </nut>
 

--- a/scripts/DMF/dmfsnmp/mge-mib.dmf
+++ b/scripts/DMF/dmfsnmp/mge-mib.dmf
@@ -49,7 +49,7 @@
 	<lookup name="mge_ambient_drycontacts_info">
 		<lookup_info oid="-1" value="unknown"/>
 		<lookup_info oid="1" value="closed"/>
-		<lookup_info oid="2" value="open"/>
+		<lookup_info oid="2" value="opened"/>
 	</lookup>
 	<lookup name="mge_beeper_status_info">
 		<lookup_info oid="1" value="disabled"/>
@@ -149,6 +149,6 @@
 		<snmp_info command="yes" default="" multiplier="20.0" name="load.off.delay" oid="1.3.6.1.2.1.33.1.8.2.0"/>
 		<snmp_info command="yes" default="" multiplier="30.0" name="load.on.delay" oid="1.3.6.1.2.1.33.1.8.3.0"/>
 	</snmp>
-	<mib2nut auto_check=".1.3.6.1.4.1.705.1.1.1.0" mib_name="mge" name="mge" oid=".1.3.6.1.4.1.705.1" snmp_info="mge_mib" version="0.52"/>
+	<mib2nut auto_check=".1.3.6.1.4.1.705.1.1.1.0" mib_name="mge" name="mge" oid=".1.3.6.1.4.1.705.1" snmp_info="mge_mib" version="0.53"/>
 </nut>
 

--- a/scripts/DMF/dmfsnmp/powerware-mib.dmf
+++ b/scripts/DMF/dmfsnmp/powerware-mib.dmf
@@ -29,9 +29,9 @@
 	</lookup>
 	<lookup name="pw_ambient_drycontacts_info">
 		<lookup_info oid="-1" value="unknown"/>
-		<lookup_info oid="1" value="open"/>
+		<lookup_info oid="1" value="opened"/>
 		<lookup_info oid="2" value="closed"/>
-		<lookup_info oid="3" value="open"/>
+		<lookup_info oid="3" value="opened"/>
 		<lookup_info oid="4" value="closed"/>
 	</lookup>
 	<lookup name="pw_batt_test_info">
@@ -199,7 +199,7 @@
 		<snmp_info command="yes" default="" flag_ok="yes" multiplier="20.0" name="load.on.delay" oid="1.3.6.1.4.1.534.1.9.2"/>
 		<snmp_info default="" multiplier="1.0" name="ups.alarms" oid="1.3.6.1.4.1.534.1.7.1.0" power_status="yes"/>
 	</snmp>
-	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pw" name="powerware" oid=".1.3.6.1.4.1.534.1" snmp_info="pw_mib" version="0.91"/>
-	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pxgx_ups" name="pxgx_ups" oid=".1.3.6.1.4.1.534.2.12" snmp_info="pw_mib" version="0.91"/>
+	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pw" name="powerware" oid=".1.3.6.1.4.1.534.1" snmp_info="pw_mib" version="0.92"/>
+	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pxgx_ups" name="pxgx_ups" oid=".1.3.6.1.4.1.534.2.12" snmp_info="pw_mib" version="0.92"/>
 </nut>
 


### PR DESCRIPTION
While "open" is the best adjective for the opposite of "closed", and thus
suitable for GPI status, this may lead to confusion with the GPO actions
"open|close" Vs the GPI status "opened|closed". These last are also not
inapropriate, since they can refer to the fact that the GPI state has change
due to some external action or event

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>