### PR TITLE
[DO NOT MERGE] Reference: https://github.com/networkupstools/nut/pull/473

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -374,19 +374,35 @@ const char * dflt_statepath(void)
 {
 	const char * path;
 
-	if ((path = getenv("NUT_STATEPATH")) == NULL)
+	path = getenv("NUT_STATEPATH");
+	if ( (path == NULL) || (*path == '\0') )
 		path = STATEPATH;
 
 	return path;
 }
 
-/* Return the alternate path for pid files */
+/* Return the alternate path for pid files, for processes running as non-root
+ * Per documentation and configure script, the fallback value is the
+ * state-file path as the daemon and drivers can write there too.
+ * Note that this differs from PIDPATH that higher-privileged daemons, such
+ * as upsmon, tend to use.
+ */
 const char * altpidpath(void)
 {
+	const char * path;
+
+	path = getenv("NUT_ALTPIDPATH");
+	if ( (path == NULL) || (*path == '\0') )
+		path = getenv("NUT_STATEPATH");
+
+	if ( (path != NULL) && (*path != '\0') )
+		return path;
+
 #ifdef ALTPIDPATH
 	return ALTPIDPATH;
 #else
-	return dflt_statepath();
+/* We assume, here and elsewhere, that at least STATEPATH is always defined */
+	return STATEPATH;
 #endif
 }
 

--- a/drivers/main.c
+++ b/drivers/main.c
@@ -98,7 +98,11 @@ static void help_msg(void)
 
 	printf("  -s <id>        - configure directly from cmd line arguments\n");
 	printf("                 - note: must specify all driver parameters with successive -x\n");
-	printf("                 - note: at least 'port' variable should be set\n\n");
+	printf("                 - note: at least 'port' variable should be set\n");
+	printf("                 - note: to explore the current values on a device from an\n");
+	printf("                   unprivileged user account (with sufficient media access in\n");
+	printf("                   the OS - e.g. to query networked devices), you can specify\n");
+	printf("                   '-d 1' argument and `export NUT_STATEPATH=/tmp` beforehand\n\n");
 
 	printf("  -V             - print version, then exit\n");
 	printf("  -L             - print parseable list of driver variables\n");


### PR DESCRIPTION
fty-discovery needs and uses successfully this fix provided by @jimklimov, thanks to him.
This fix allow fty-discovery to do straightforward exec "/lib/nut/snmp-ups -s dumpdataXXX" and manage successfully timeout (signal SIGTERM/SIGKILL).

Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>
