### PR TITLE
Problem: snmp-ups segfaults

### DIFF
--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -2225,20 +2225,22 @@ bool_t daisychain_init()
 			}
 		}
 
-        /* Finally, compute and store the base OID index and NUT offset */
-        su_info_p = su_find_info("device.model");
-        if (su_info_p != NULL)
-        {
-            device_template_index_base = base_snmp_template_index(su_info_p);
-            upsdebugx(1, "%s: device_template_index_base = %i", __func__, device_template_index_base);
-            device_template_offset = device_template_index_base - 1;
-            upsdebugx(1, "%s: device_template_offset = %i", __func__, device_template_offset);
-        }
     }
 	else {
 		daisychain_enabled = FALSE;
 		upsdebugx(1, "No device.count entry found, daisychain support not needed");
 	}
+
+    /* Finally, compute and store the base OID index and NUT offset */
+    su_info_p = su_find_info("device.model");
+    if (su_info_p != NULL) {
+        device_template_index_base = base_snmp_template_index(su_info_p);
+        upsdebugx(1, "%s: device_template_index_base = %i", __func__, device_template_index_base);
+        device_template_offset = device_template_index_base - 1;
+        upsdebugx(1, "%s: device_template_offset = %i", __func__, device_template_offset);
+    }
+
+
 
 	return daisychain_enabled;
 }

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -2224,7 +2224,6 @@ bool_t daisychain_init()
 				dstate_setinfo("device.model", "daisychain (1+%ld)", devices_count - 1);
 			}
 		}
-
     }
 	else {
 		daisychain_enabled = FALSE;
@@ -2239,8 +2238,9 @@ bool_t daisychain_init()
         device_template_offset = device_template_index_base - 1;
         upsdebugx(1, "%s: device_template_offset = %i", __func__, device_template_offset);
     }
-
-
+    else {
+        upsdebugx(1, "%s: No device.model entry found.", __func__);
+    }
 
 	return daisychain_enabled;
 }

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -561,18 +561,18 @@ void upsdrv_initups(void)
 		dstate_addcmd("shutdown.return");
 		dstate_addcmd("shutdown.stayoff");
 	}
-	/* Publish sysContact and sysLocation for all subdrivers */  
-	/* sysContact.0 */  
-	if (nut_snmp_get_str(".1.3.6.1.2.1.1.4.0", model, sizeof(model), NULL) == TRUE)  
-		dstate_setinfo("device.contact", "%s", model);  
-	else  
-		upsdebugx(2, "Can't get and publish sysContact for device.contact");  
-  
-	/* sysLocation.0 */  
-	if (nut_snmp_get_str(".1.3.6.1.2.1.1.6.0", model, sizeof(model), NULL) == TRUE)  
-		dstate_setinfo("device.location", "%s", model);  
-	else  
-		upsdebugx(2, "Can't get and publish sysLocation for device.location");  
+	/* Publish sysContact and sysLocation for all subdrivers */
+	/* sysContact.0 */
+	if (nut_snmp_get_str(".1.3.6.1.2.1.1.4.0", model, sizeof(model), NULL) == TRUE)
+		dstate_setinfo("device.contact", "%s", model);
+	else
+		upsdebugx(2, "Can't get and publish sysContact for device.contact");
+
+	/* sysLocation.0 */
+	if (nut_snmp_get_str(".1.3.6.1.2.1.1.6.0", model, sizeof(model), NULL) == TRUE)
+		dstate_setinfo("device.location", "%s", model);
+	else
+		upsdebugx(2, "Can't get and publish sysLocation for device.location");
 }
 
 void upsdrv_cleanup(void)
@@ -1753,6 +1753,9 @@ void free_info(snmp_info_t *su_info_p)
  * the MIB, based on a test using a template OID */
 int base_snmp_template_index(const snmp_info_t *su_info_p)
 {
+    if (!su_info_p)
+        return -1;
+
 	int base_index = -1;
 	char test_OID[SU_INFOSIZE];
 	int template_type = get_template_type(su_info_p->info_type);
@@ -2221,17 +2224,21 @@ bool_t daisychain_init()
 				dstate_setinfo("device.model", "daisychain (1+%ld)", devices_count - 1);
 			}
 		}
-	}
+
+        /* Finally, compute and store the base OID index and NUT offset */
+        su_info_p = su_find_info("device.model");
+        if (su_info_p != NULL)
+        {
+            device_template_index_base = base_snmp_template_index(su_info_p);
+            upsdebugx(1, "%s: device_template_index_base = %i", __func__, device_template_index_base);
+            device_template_offset = device_template_index_base - 1;
+            upsdebugx(1, "%s: device_template_offset = %i", __func__, device_template_offset);
+        }
+    }
 	else {
 		daisychain_enabled = FALSE;
 		upsdebugx(1, "No device.count entry found, daisychain support not needed");
 	}
-
-	/* Finally, compute and store the base OID index and NUT offset */
-	device_template_index_base = base_snmp_template_index(su_find_info("device.model"));
-	upsdebugx(1, "%s: device_template_index_base = %i", __func__, device_template_index_base);
-	device_template_offset = device_template_index_base - 1;
-	upsdebugx(1, "%s: device_template_offset = %i", __func__, device_template_offset);
 
 	return daisychain_enabled;
 }


### PR DESCRIPTION
Solution:  base_snmp_template_index() prevented from processing empty argument

Signed-off-by: Barbora Stepankova <BarboraStepankova@eaton.com>