### PR TITLE
upsd should return EXIT_FAILURE when -c failed

### DIFF
--- a/server/upsd.c
+++ b/server/upsd.c
@@ -890,7 +890,7 @@ void check_perms(const char *fn)
 
 int main(int argc, char **argv)
 {
-	int	i, cmd = 0;
+	int	i, cmd = 0, cmdret = 0;
 	char	*chroot_path = NULL;
 	const char	*user = RUN_AS_USER;
 	struct passwd	*new_uid = NULL;
@@ -959,8 +959,8 @@ int main(int argc, char **argv)
 	}
 
 	if (cmd) {
-		sendsignalfn(pidfn, cmd);
-		exit(EXIT_SUCCESS);
+		cmdret = sendsignalfn(pidfn, cmd);
+		exit((cmdret == 0)?EXIT_SUCCESS:EXIT_FAILURE);
 	}
 
 	/* otherwise, we are being asked to start.


### PR DESCRIPTION
Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>
(cherry picked from commit f7d80a29610a43c08e43c9db1c7bca7c051c3c1a)