### PR TITLE
Support nut-driver-enumerator-daemon systemd service

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1762,6 +1762,9 @@ AC_OUTPUT([
  scripts/systemd/nut-server.service
  scripts/systemd/nut-driver-enumerator.service
  scripts/systemd/nut-driver-enumerator.path
+ scripts/systemd/nut-driver-enumerator-daemon.service
+ scripts/systemd/nut-driver-enumerator-daemon-activator.service
+ scripts/systemd/nut-driver-enumerator-daemon-activator.path
  scripts/systemd/nutshutdown
  scripts/Solaris/nut-driver-enumerator.xml
  scripts/Solaris/nut-driver.xml

--- a/docs/config-notes.txt
+++ b/docs/config-notes.txt
@@ -227,6 +227,17 @@ at its startup. This helper service should be triggered whenever your system
 (re-)starts the `nut-server` service, so that it runs against an up-to-date
 list of NUT driver processes.
 
+Two service bundles are provided for this feature: a set of
+`nut-driver-enumerator-daemon*` units starts the script as a daemon
+to regularly inspect and apply the NUT configuration to OS service unit
+wrappings (mainly intended for monitoring systems with a dynamic set of
+monitored power devices, or for systems where filesystem events monitoring
+is not a clockwork-reliable mechanism to 100% rely on); while the other
+`nut-driver-enumerator.*` units run the script once per triggering of
+the service (usually during boot-up; configuration file changes can be
+detected and propagated by systemd most of the time, but not by SMF out
+of the box).
+
 A service-oriented solution also allows to consider that different drivers
 have different dependencies -- such as that networked drivers should begin
 startup after IP addresses have been assigned, while directly-connected

--- a/scripts/Solaris/nut-driver-enumerator.xml.in
+++ b/scripts/Solaris/nut-driver-enumerator.xml.in
@@ -128,7 +128,7 @@
 			<exec_method
 			type='method'
 			name='start'
-			exec='@NUT_LIBEXECDIR@/nut-driver-enumerator.sh --daemon'
+			exec='@NUT_LIBEXECDIR@/nut-driver-enumerator.sh --daemon-after'
 			timeout_seconds='0'/>
 
 			<exec_method

--- a/scripts/systemd/.gitignore
+++ b/scripts/systemd/.gitignore
@@ -6,3 +6,6 @@
 /nutshutdown
 /nut-driver-enumerator.service
 /nut-driver-enumerator.path
+/nut-driver-enumerator-daemon-activator.path
+/nut-driver-enumerator-daemon-activator.service
+/nut-driver-enumerator-daemon.service

--- a/scripts/systemd/Makefile.am
+++ b/scripts/systemd/Makefile.am
@@ -5,6 +5,9 @@ if HAVE_SYSTEMD
 systemdsystemunit_DATA = \
         nut-driver-enumerator.service \
         nut-driver-enumerator.path \
+        nut-driver-enumerator-daemon-activator.path \
+        nut-driver-enumerator-daemon-activator.service \
+        nut-driver-enumerator-daemon.service \
         nut-driver@.service \
         nut-monitor.service \
         nut-server.service  \
@@ -22,6 +25,9 @@ sbin_SCRIPTS = ../upsdrvsvcctl/upsdrvsvcctl
 else
 EXTRA_DIST += nut-driver@.service.in nut-monitor.service.in \
 	nut-server.service.in nutshutdown.in nut-driver.target nut.target \
-	nut-driver-enumerator.path.in nut-driver-enumerator.service.in
+	nut-driver-enumerator.path.in nut-driver-enumerator.service.in \
+	nut-driver-enumerator-daemon-activator.path.in \
+	nut-driver-enumerator-daemon-activator.service.in \
+	nut-driver-enumerator-daemon.service.in
 endif
 

--- a/scripts/systemd/README
+++ b/scripts/systemd/README
@@ -4,9 +4,17 @@ Service Manager.
 These files are automatically installed, upon detection (at configure time)
 of a systemd enabled system.
 
-This also uses the nut-driver-enumerator.sh (service and implementation
-method) and upsdrvsvcctl (tool) to manage NUT drivers as service instances
-located in ../upsdrvsvcctl/ source subdirectory.
+This also uses the `nut-driver-enumerator.sh` (service and implementation
+method) and `upsdrvsvcctl` (tool) to manage NUT drivers as service instances
+located in `../upsdrvsvcctl/` source subdirectory. Two service bundles are
+provided for this: a set of `nut-driver-enumerator-daemon*` units starts
+the script as a daemon to regularly inspect and apply the NUT configuration
+to OS service unit wrappings (mainly intended for monitoring systems with
+a dynamic set of monitored power devices, or for systems where filesystem
+events monitoring is not a clockwork-reliable mechanism to 100% rely on);
+the other `nut-driver-enumerator.*` units run the script once per triggering
+of the service (usually during boot-up; configuration file changes can be
+detected and propagated by systemd most of the time).
 
 Contributed by Michal Hlavinka <mhlavink@redhat.com>
 Updated 2016-2018 by Michal Hrusecky and Jim Klimov <EvgenyKlimov@eaton.com>

--- a/scripts/systemd/nut-driver-enumerator-daemon-activator.path.in
+++ b/scripts/systemd/nut-driver-enumerator-daemon-activator.path.in
@@ -1,0 +1,15 @@
+# Trigger restart of nut-driver-enumerator-daemon-activator.service
+# whenever ups.conf is edited, which would cause reload-or-restart
+# of the nut-driver-enumerator-daemon.service for actual reconfig.
+[Unit]
+Description=Network UPS Tools - Trigger restart of nut-driver-enumerator-daemon.service whenever ups.conf is edited
+Conflicts=nut-driver-enumerator.service nut-driver-enumerator.path
+After=local-fs.target
+Before=nut-driver.target
+PartOf=nut.target
+
+[Path]
+PathModified=@CONFPATH@/ups.conf
+
+[Install]
+WantedBy=nut.target

--- a/scripts/systemd/nut-driver-enumerator-daemon-activator.service.in
+++ b/scripts/systemd/nut-driver-enumerator-daemon-activator.service.in
@@ -21,6 +21,8 @@ Type=simple
 # or should be aborted and retried if it does (system bugs)
 TimeoutStartSec=10s
 Restart=always
+StartLimitInterval=15s
+StartLimitBurst=3
 ExecStart=/bin/systemctl reload-or-restart --no-block nut-driver-enumerator-daemon.service
 
 [Install]

--- a/scripts/systemd/nut-driver-enumerator-daemon-activator.service.in
+++ b/scripts/systemd/nut-driver-enumerator-daemon-activator.service.in
@@ -16,13 +16,10 @@ After=local-fs.target
 #User=@RUN_AS_USER@
 #Group=@RUN_AS_GROUP@
 User=root
-Type=simple
+Type=oneshot
 # Non-blocking systemd message posting should not take long,
 # or should be aborted and retried if it does (system bugs)
 TimeoutStartSec=10s
-Restart=always
-StartLimitInterval=15s
-StartLimitBurst=3
 ExecStart=/bin/systemctl reload-or-restart --no-block nut-driver-enumerator-daemon.service
 
 [Install]

--- a/scripts/systemd/nut-driver-enumerator-daemon-activator.service.in
+++ b/scripts/systemd/nut-driver-enumerator-daemon-activator.service.in
@@ -1,0 +1,25 @@
+[Unit]
+# This unit starts via nut-driver-enumerator-daemon-activator.path
+# activation due to changes in ups.conf file, and triggers a reload
+# of the nut-driver-enumerator-daemon.service so that one quickly
+# re-processes the new configuration state.
+Description=Network UPS Tools - enumeration of configure-file devices into systemd unit instances (FS event-based activator for daemonized mode)
+Conflicts=nut-driver-enumerator.service nut-driver-enumerator.path
+After=local-fs.target
+Before=nut-driver.target
+PartOf=nut.target
+
+[Service]
+### Script needs privileges to restart units
+#User=@RUN_AS_USER@
+#Group=@RUN_AS_GROUP@
+User=root
+Type=simple
+# Non-blocking systemd message posting should not take long,
+# or should be aborted and retried if it does (system bugs)
+TimeoutStartSec=10s
+Restart=always
+ExecStart=/bin/systemctl reload-or-restart --no-block nut-driver-enumerator-daemon.service
+
+[Install]
+WantedBy=nut.target

--- a/scripts/systemd/nut-driver-enumerator-daemon-activator.service.in
+++ b/scripts/systemd/nut-driver-enumerator-daemon-activator.service.in
@@ -3,11 +3,13 @@
 # activation due to changes in ups.conf file, and triggers a reload
 # of the nut-driver-enumerator-daemon.service so that one quickly
 # re-processes the new configuration state.
+# NOTE: This unit is intentionally not installed as PartOf/WantedBy
+# anything, as it is only meant to be triggered by the path unit.
 Description=Network UPS Tools - enumeration of configure-file devices into systemd unit instances (FS event-based activator for daemonized mode)
 Conflicts=nut-driver-enumerator.service nut-driver-enumerator.path
 After=local-fs.target
-Before=nut-driver.target
-PartOf=nut.target
+#Before=nut-driver.target
+#PartOf=nut.target
 
 [Service]
 ### Script needs privileges to restart units
@@ -22,4 +24,5 @@ Restart=always
 ExecStart=/bin/systemctl reload-or-restart --no-block nut-driver-enumerator-daemon.service
 
 [Install]
-WantedBy=nut.target
+### No install, see comment above
+#WantedBy=nut.target

--- a/scripts/systemd/nut-driver-enumerator-daemon.service.in
+++ b/scripts/systemd/nut-driver-enumerator-daemon.service.in
@@ -20,7 +20,7 @@ User=root
 Type=forking
 Restart=always
 Environment=REPORT_RESTART_42=no
-ExecStart=@NUT_LIBEXECDIR@/nut-driver-enumerator.sh --daemon
+ExecStart=@NUT_LIBEXECDIR@/nut-driver-enumerator.sh --daemon-after
 # Note: this is an async event, actual reconfiguration may take some time to
 # complete after this signal.
 ExecReload=/bin/kill -HUP $MAINPID

--- a/scripts/systemd/nut-driver-enumerator-daemon.service.in
+++ b/scripts/systemd/nut-driver-enumerator-daemon.service.in
@@ -15,14 +15,9 @@ PartOf=nut.target
 #User=@RUN_AS_USER@
 #Group=@RUN_AS_GROUP@
 User=root
-# it is expected that the process has to exit before systemd starts follow-up
-# units; it should not be a problem for those
-Type=simple
-# Currently systemd does not support restarting of oneshot services, and does
-# not seem to guarantee that other services would only start after the script
-# completes, for a non-oneshot case. The script itself handles restarting of
-# nut-server which is the primary concerned dependency at the moment, so we
-# don't want it to fail the unit (when it can't restart).
+# it is expected that this process has to fork the daemon before systemd
+# starts follow-up units; it should not be a problem for those
+Type=forking
 Restart=always
 Environment=REPORT_RESTART_42=no
 ExecStart=@NUT_LIBEXECDIR@/nut-driver-enumerator.sh --daemon

--- a/scripts/systemd/nut-driver-enumerator-daemon.service.in
+++ b/scripts/systemd/nut-driver-enumerator-daemon.service.in
@@ -1,9 +1,11 @@
 [Unit]
-# This unit starts early in system lifecycle to set up nut-driver instances.
+# This unit starts early in system lifecycle to set up nut-driver instances
+# and stays running as a loop to pick up any subsequent changes maybe more
+# reliably than the filesystem notification processing would allow.
 # End-user may also restart this unit after editing ups.conf to automatically
 # un-register or add new instances as appropriate.
-Description=Network UPS Tools - enumeration of configure-file devices into systemd unit instances
-Conflicts=nut-driver-enumerator-daemon.service nut-driver-enumerator-daemon-activator.path nut-driver-enumerator-daemon-activator.service
+Description=Network UPS Tools - enumeration of configure-file devices into systemd unit instances (daemonized mode)
+Conflicts=nut-driver-enumerator.service nut-driver-enumerator.path
 After=local-fs.target
 Before=nut-driver.target
 PartOf=nut.target
@@ -15,15 +17,18 @@ PartOf=nut.target
 User=root
 # it is expected that the process has to exit before systemd starts follow-up
 # units; it should not be a problem for those
-Type=oneshot
+Type=simple
 # Currently systemd does not support restarting of oneshot services, and does
 # not seem to guarantee that other services would only start after the script
 # completes, for a non-oneshot case. The script itself handles restarting of
 # nut-server which is the primary concerned dependency at the moment, so we
 # don't want it to fail the unit (when it can't restart).
+Restart=always
 Environment=REPORT_RESTART_42=no
-ExecStart=@NUT_LIBEXECDIR@/nut-driver-enumerator.sh
-ExecReload=@NUT_LIBEXECDIR@/nut-driver-enumerator.sh
+ExecStart=@NUT_LIBEXECDIR@/nut-driver-enumerator.sh --daemon
+# Note: this is an async event, actual reconfiguration may take some time to
+# complete after this signal.
+ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]
 WantedBy=nut.target

--- a/scripts/systemd/nut-driver-enumerator.path.in
+++ b/scripts/systemd/nut-driver-enumerator.path.in
@@ -1,4 +1,9 @@
-# Trigger restart of nut-driver-enumerator.service whenever ups.conf is edited
+[Unit]
+Description=Network UPS Tools - Trigger restart of nut-driver-enumerator.service whenever ups.conf is edited
+Conflicts=nut-driver-enumerator-daemon.service nut-driver-enumerator-daemon-activator.path nut-driver-enumerator-daemon-activator.service
+After=local-fs.target
+Before=nut-driver.target
+PartOf=nut.target
 
 [Path]
 PathModified=@CONFPATH@/ups.conf

--- a/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
+++ b/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
@@ -948,12 +948,18 @@ TERMINATION_SIGNALS="2 3 15"
 RECONFIGURATION_SIGNALS="1"
 
 TERMINATE_ASAP=false
+trap_handle_interruption_exit() {
+    # Handle SIGINT, SIGQUIT, SIGTERM with a message
+    echo "`date -u` : Received an interruption signal, terminating the script now" >&2
+    exit 0
+}
+
 trap_handle_interruption() {
     # Handle SIGINT, SIGQUIT, SIGTERM gracefully - tell the main
     # iteration to complete and just then abort
     echo "`date -u` : Received an interruption signal, will terminate the script after ending the main routine. Repeat the signal if urgent!" >&2
     TERMINATE_ASAP=true
-    trap '-' $TERMINATION_SIGNALS
+    trap 'trap_handle_interruption_exit' $TERMINATION_SIGNALS
 }
 
 nut_driver_enumerator_main() {
@@ -1109,7 +1115,7 @@ daemonize() {
     # gets applied (e.g. if user disabled some services or they
     # died, or some config was not applied due to coding error).
     while nut_driver_enumerator_main ; do
-        trap '-' $TERMINATION_SIGNALS
+        trap 'trap_handle_interruption_exit' $TERMINATION_SIGNALS
         if $TERMINATE_ASAP ; then
             echo "`date -u` : Trapped a SIGTERM/SIGINT/SIGQUIT during last run of nut_driver_enumerator_main, terminating gracefully now" >&2
             exit 0

--- a/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
+++ b/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
@@ -1094,8 +1094,14 @@ if [ $# = 1 ] ; then
     # Note: Not all shells have 'case ... ;&' support
     case "$1" in
         --daemon=*) DAEMON_SLEEP="`echo "$1" | sed 's,^--daemon=,,'`" ;;
+        --daemon-after=*) DAEMON_SLEEP="`echo "$1" | sed 's,^--daemon-after=,,'`" ;;
     esac
     case "$1" in
+        --daemon-after|--daemon-after=*)
+            REPORT_RESTART_42=no nut_driver_enumerator_main || exit $?
+            daemonize &
+            exit $?
+            ;;
         --daemon|--daemon=*)
             daemonize &
             exit $?
@@ -1110,6 +1116,10 @@ $0 (no args)
         Update wrapping of devices into services
 $0 --daemon(=freq)
         Update wrapping of devices into services in an infinite loop
+        Default freq is 60 sec
+$0 --daemon-after(=freq)
+        Update wrapping of devices into services in an infinite loop
+        First do one run of the loop though
         Default freq is 60 sec
 $0 --reconfigure
         Stop and un-register all service instances and recreate them

--- a/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
+++ b/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
@@ -941,8 +941,25 @@ upslist_restartSvcs() {
     done
 }
 
+# FIXME : process via kill -l?
+# Different shells use a SIG prefix or not to signal names
+# so standard numbers are in fact more portable :\
+TERMINATION_SIGNALS="2 3 15"
+RECONFIGURATION_SIGNALS="1"
+
+TERMINATE_ASAP=false
+trap_handle_interruption() {
+    # Handle SIGINT, SIGQUIT, SIGTERM gracefully - tell the main
+    # iteration to complete and just then abort
+    echo "`date -u` : Received an interruption signal, will terminate the script after ending the main routine. Repeat the signal if urgent!" >&2
+    TERMINATE_ASAP=true
+    trap '-' $TERMINATION_SIGNALS
+}
+
 nut_driver_enumerator_main() {
     ################# MAIN PROGRAM by default
+    TERMINATE_ASAP=false
+    trap 'trap_handle_interruption' $TERMINATION_SIGNALS
 
     # Note: do not use the read..._once() here, to ensure that the
     # looped daemon sees the whole picture, which can be new every time
@@ -1072,7 +1089,7 @@ daemonize() {
     # e.g. to request it while the sleep is happening or while
     # "main" is processing an earlier change of the file.
     RECONFIGURE_ASAP=false
-    trap 'trap_handle_hup_main' 1
+    trap 'trap_handle_hup_main' $RECONFIGURATION_SIGNALS
 
     # Note: this loop would die on errors with config file or
     # inability to ensure that it matches the list of services.
@@ -1085,15 +1102,21 @@ daemonize() {
     # gets applied (e.g. if user disabled some services or they
     # died, or some config was not applied due to coding error).
     while nut_driver_enumerator_main ; do
+        trap '-' $TERMINATION_SIGNALS
+        if $TERMINATE_ASAP ; then
+            echo "`date -u` : Trapped a SIGTERM/SIGINT/SIGQUIT during last run of nut_driver_enumerator_main, terminating gracefully now" >&2
+            exit 0
+        fi
+
         if $RECONFIGURE_ASAP ; then
             echo "`date -u` : Trapped a SIGHUP during last run of nut_driver_enumerator_main, repeating reconfiguration quickly" >&2
         else
             sleep $DAEMON_SLEEP &
-            trap "trap_handle_hup_sleep $!" 1
+            trap "trap_handle_hup_sleep $!" $RECONFIGURATION_SIGNALS
             wait $!
         fi
         RECONFIGURE_ASAP=false
-        trap 'trap_handle_hup_main' 1
+        trap 'trap_handle_hup_main' $RECONFIGURATION_SIGNALS
     done
     exit $?
 }

--- a/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
+++ b/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
@@ -1069,11 +1069,18 @@ nut_driver_enumerator_main() {
 RECONFIGURE_ASAP=false
 trap_handle_hup_main() {
     echo "`date -u` : Received a HUP during processing, scheduling reconfiguration to repeat ASAP (after the current iteration is done)" >&2
+    # Note: in the worst case the reconfig would run twice;
+    # we do not update UPSCONF_CHECKSUM_START in this case
+    # to avoid corrupting decisions of the currently running
+    # processing.
     RECONFIGURE_ASAP=true
 }
 
 trap_handle_hup_sleep() {
     echo "`date -u` : Received a HUP in my sleep, reprocessing reconfigs right now!" >&2
+    # Avoid re-parsing main twice, though don't recalculate
+    # checksums needlessly on every loop cycle, either...
+    UPSCONF_CHECKSUM_START="`calc_md5_file "$UPSCONF"`" || true
     RECONFIGURE_ASAP=true
     if [ -n "$1" ] ; then
         # Kill the sleeper PID

--- a/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
+++ b/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
@@ -1049,7 +1049,10 @@ nut_driver_enumerator_main() {
     return 13
 }
 
-daemonize() (
+daemonize() {
+    # Note: do not further sub-shell this routine, so systemd
+    # is not confused whom to signal.
+
     # Support (SIG)HUP == signal code 1 to quickly reconfigure,
     # e.g. to request it while the sleep is happening or while
     # "main" is processing an earlier change of the file.
@@ -1078,7 +1081,7 @@ daemonize() (
         trap 'RECONFIGURE_ASAP=true' 1
     done
     exit $?
-)
+}
 
 # Save the checksum of ups.conf as early as possible,
 # to test in the end that it is still the same file.

--- a/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
+++ b/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
@@ -1034,6 +1034,9 @@ nut_driver_enumerator_main() {
         # can be configured into an uncomfortably long lag, so
         # we should re-sync the system config in any case.
         echo "`date -u` : '$UPSCONF' changed while $0 $* was processing its older contents; re-running the script to pick up the late-coming changes"
+        # Make sure the cycle does not repeat itself due to diffs
+        # from an ages-old state of the file from when we started.
+        UPSCONF_CHECKSUM_START="$UPSCONF_CHECKSUM_END"
         ( nut_driver_enumerator_main ) ; return $?
         # The "main" routine at the end of recursions will
         # do REPORT_RESTART_42 logic or the error exit-code

--- a/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
+++ b/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
@@ -1050,7 +1050,12 @@ nut_driver_enumerator_main() {
 }
 
 daemonize() (
-    trap '-' 1
+    # Support (SIG)HUP == signal code 1 to quickly reconfigure,
+    # e.g. to request it while the sleep is happening or while
+    # "main" is processing an earlier change of the file.
+    RECONFIGURE_ASAP=false
+    trap 'RECONFIGURE_ASAP=true' 1
+
     # Note: this loop would die on errors with config file or
     # inability to ensure that it matches the list of services.
     # If caller did not `export REPORT_RESTART_42=no` then the
@@ -1058,10 +1063,15 @@ daemonize() (
     # of the service which wraps this daemon do topple others that
     # depend on it.
     while nut_driver_enumerator_main ; do
-        sleep $DAEMON_SLEEP &
-        trap "kill $! ; echo 'Sleep interrupted, processing configs now!'>&2" 1
-        wait $!
-        trap '-' 1
+        if $RECONFIGURE_ASAP ; then
+            echo "`date -u` : Trapped a SIGHUP during last run of nut_driver_enumerator_main, repeating reconfiguration quickly" >&2
+        else
+            sleep $DAEMON_SLEEP &
+            trap "kill $! ; echo 'Sleep interrupted, processing configs now!'>&2" 1
+            wait $!
+        fi
+        RECONFIGURE_ASAP=false
+        trap 'RECONFIGURE_ASAP=true' 1
     done
     exit $?
 )

--- a/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
+++ b/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
@@ -1083,7 +1083,7 @@ trap_handle_hup_main() {
 }
 
 trap_handle_hup_sleep() {
-    echo "`date -u` : Received a HUP in my sleep, reprocessing reconfigs right now!" >&2
+    echo "`date -u` : Received a HUP in my sleep, reprocessing configs right now!" >&2
     # Avoid re-parsing main twice, though don't recalculate
     # checksums needlessly on every loop cycle, either...
     UPSCONF_CHECKSUM_START="`calc_md5_file "$UPSCONF"`" || true

--- a/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
+++ b/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
@@ -1049,6 +1049,21 @@ nut_driver_enumerator_main() {
     return 13
 }
 
+RECONFIGURE_ASAP=false
+trap_handle_hup_main() {
+    echo "`date -u` : Received a HUP during processing, scheduling reconfiguration to repeat ASAP (after the current iteration is done)" >&2
+    RECONFIGURE_ASAP=true
+}
+
+trap_handle_hup_sleep() {
+    echo "`date -u` : Received a HUP in my sleep, reprocessing reconfigs right now!" >&2
+    RECONFIGURE_ASAP=true
+    if [ -n "$1" ] ; then
+        # Kill the sleeper PID
+        kill "$1"
+    fi
+}
+
 daemonize() {
     # Note: do not further sub-shell this routine, so systemd
     # is not confused whom to signal.
@@ -1057,7 +1072,7 @@ daemonize() {
     # e.g. to request it while the sleep is happening or while
     # "main" is processing an earlier change of the file.
     RECONFIGURE_ASAP=false
-    trap 'RECONFIGURE_ASAP=true' 1
+    trap 'trap_handle_hup_main' 1
 
     # Note: this loop would die on errors with config file or
     # inability to ensure that it matches the list of services.
@@ -1074,11 +1089,11 @@ daemonize() {
             echo "`date -u` : Trapped a SIGHUP during last run of nut_driver_enumerator_main, repeating reconfiguration quickly" >&2
         else
             sleep $DAEMON_SLEEP &
-            trap "kill $! ; echo 'Sleep interrupted, processing configs now!'>&2" 1
+            trap "trap_handle_hup_sleep $!" 1
             wait $!
         fi
         RECONFIGURE_ASAP=false
-        trap 'RECONFIGURE_ASAP=true' 1
+        trap 'trap_handle_hup_main' 1
     done
     exit $?
 }

--- a/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
+++ b/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
@@ -1062,6 +1062,10 @@ daemonize() (
     # loop would exit with code 42, and probably trigger restart
     # of the service which wraps this daemon do topple others that
     # depend on it.
+    # Note: do not quickly skip the "main" based on full-file
+    # checksum refresh, to ensure that whatever is configured
+    # gets applied (e.g. if user disabled some services or they
+    # died, or some config was not applied due to coding error).
     while nut_driver_enumerator_main ; do
         if $RECONFIGURE_ASAP ; then
             echo "`date -u` : Trapped a SIGHUP during last run of nut_driver_enumerator_main, repeating reconfiguration quickly" >&2

--- a/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
+++ b/scripts/upsdrvsvcctl/nut-driver-enumerator.sh.in
@@ -1097,6 +1097,7 @@ trap_handle_hup_sleep() {
 daemonize() {
     # Note: do not further sub-shell this routine, so systemd
     # is not confused whom to signal.
+    echo "`date -u` : Daemonizing $0 with config re-evaluation frequency $DAEMON_SLEEP" >&2
 
     # Support (SIG)HUP == signal code 1 to quickly reconfigure,
     # e.g. to request it while the sleep is happening or while


### PR DESCRIPTION
Try a more robust solution to problem tackled in #69 by addressing potential issues, and also wrapping the daemonized mode as a service.

Follow-ups to use it after this is merged should include:
* fty-nut : tickling `nut-driver-enumerator-daemon.service` rather than `nut-driver-enumerator.service` in fty-nut reconfiguration script, to request a re-evaluation cycle ASAP
* fty-core : when preparing the OS image, make sure to enable just one implementation of the service bundle (they are marked to conflict)
