### PR TITLE
SNMP Eaton Gb Network Card: various data completion

### DIFF
--- a/drivers/nut-libfreeipmi.c
+++ b/drivers/nut-libfreeipmi.c
@@ -351,16 +351,16 @@ static int libfreeipmi_get_psu_info (const void *areabuf,
 	unsigned int overall_capacity;
 	int low_end_input_voltage_range_1;
 	int high_end_input_voltage_range_1;
-	int low_end_input_frequency_range;
-	int high_end_input_frequency_range;
+	unsigned int low_end_input_frequency_range;
+	unsigned int high_end_input_frequency_range;
 	unsigned int voltage_1;
 
 	/* FIXME: check for the interest and capability to use these data */
 	unsigned int peak_va;
 	unsigned int inrush_current;
 	unsigned int inrush_interval;
-	unsigned int low_end_input_voltage_range_2;
-	unsigned int high_end_input_voltage_range_2;
+	int low_end_input_voltage_range_2;
+	int high_end_input_voltage_range_2;
 	unsigned int ac_dropout_tolerance;
 	unsigned int predictive_fail_support;
 	unsigned int power_factor_correction;

--- a/drivers/nut-libfreeipmi.c
+++ b/drivers/nut-libfreeipmi.c
@@ -349,10 +349,10 @@ static int libfreeipmi_get_psu_info (const void *areabuf,
 
 	/* FIXME: directly use ipmi_dev fields */
 	unsigned int overall_capacity;
-	unsigned int low_end_input_voltage_range_1;
-	unsigned int high_end_input_voltage_range_1;
-	unsigned int low_end_input_frequency_range;
-	unsigned int high_end_input_frequency_range;
+	int low_end_input_voltage_range_1;
+	int high_end_input_voltage_range_1;
+	int low_end_input_frequency_range;
+	int high_end_input_frequency_range;
 	unsigned int voltage_1;
 
 	/* FIXME: check for the interest and capability to use these data */

--- a/drivers/powerware-mib.c
+++ b/drivers/powerware-mib.c
@@ -29,7 +29,7 @@
 #include "eaton-pdu-marlin-helpers.h"
 #endif
 
-#define PW_MIB_VERSION "0.97"
+#define PW_MIB_VERSION "0.98"
 
 /* TODO: more sysOID and MIBs support:
  * 
@@ -77,8 +77,8 @@
 
 #define PW_OID_BATTEST_START	"1.3.6.1.4.1.534.1.8.1"		/* XUPS-MIB::xupsTestBattery   set to startTest(1) to initiate test*/
 
-#define PW_OID_CONT_OFFDELAY	"1.3.6.1.4.1.534.1.9.1"		/* XUPS-MIB::xupsControlOutputOffDelay */
-#define PW_OID_CONT_ONDELAY	"1.3.6.1.4.1.534.1.9.2"		/* XUPS-MIB::xupsControlOutputOnDelay */
+#define PW_OID_CONT_OFFDELAY	"1.3.6.1.4.1.534.1.9.1.0"		/* XUPS-MIB::xupsControlOutputOffDelay */
+#define PW_OID_CONT_ONDELAY	"1.3.6.1.4.1.534.1.9.2.0"		/* XUPS-MIB::xupsControlOutputOnDelay */
 #define PW_OID_CONT_OFFT_DEL	"1.3.6.1.4.1.534.1.9.3"		/* XUPS-MIB::xupsControlOutputOffTrapDelay */
 #define PW_OID_CONT_ONT_DEL	"1.3.6.1.4.1.534.1.9.4"		/* XUPS-MIB::xupsControlOutputOnTrapDelay */
 #define PW_OID_CONT_LOAD_SHED_AND_RESTART	"1.3.6.1.4.1.534.1.9.6"		/* XUPS-MIB::xupsLoadShedSecsWithRestart */
@@ -233,6 +233,18 @@ static info_lkp_t pw_batt_test_info[] = {
 static info_lkp_t pw_yes_no_info[] = {
 	{ 1, "yes" },
 	{ 2, "no" },
+	{ 0, NULL }
+};
+
+static info_lkp_t pw_outlet_status_info[] = {
+	{ 1, "on" },
+	{ 2, "off" },
+	{ 3, "on" },  /* pendingOff, transitional status */
+	{ 4, "off" }, /* pendingOn, transitional status */
+	/* { 5, "" },  unknown */
+	/* { 6, "" },  reserved */
+	{ 7, "off" }, /* Failed in Closed position */
+	{ 8, "on" },  /* Failed in Open position */
 	{ 0, NULL }
 };
 
@@ -477,10 +489,9 @@ static snmp_info_t pw_mib[] = {
 	{ "input.voltage", 0, 1.0, PW_OID_IN_VOLTAGE ".0", "",
 		SU_INPUT_1, NULL },
 	/* Duplicate of the above entry, but pointing at the first index */
-	/* xupsInputVoltage.1.0; Value (Integer): 245 */
-	{ "input.voltage", 0, 1.0, "1.3.6.1.4.1.534.1.3.4.1.2.1.0", "",
+	/* xupsInputVoltage.1[.0]; Value (Integer): 245 */
+	{ "input.voltage", 0, 1.0, "1.3.6.1.4.1.534.1.3.4.1.2.1", "",
 		SU_INPUT_1, NULL },
-
 
 	/* XUPS-MIB::xupsConfigInputVoltage.0 */
 	{ "input.voltage.nominal", 0, 1.0, "1.3.6.1.4.1.534.1.10.2.0", "", 0, NULL },
@@ -522,6 +533,17 @@ static snmp_info_t pw_mib[] = {
 		SU_INPUT_3, NULL },
 	{ "input.bypass.L3-N.voltage", 0, 1.0, PW_OID_BY_VOLTAGE ".3", "",
 		SU_INPUT_3, NULL },
+
+	/* Outlet page */
+	/* XUPS-MIB::xupsNumReceptacles; Value (Integer): 2 */
+	{ "outlet.count", 0, 1, ".1.3.6.1.4.1.534.1.12.1.0", NULL, SU_FLAG_STATIC, NULL },
+	/* XUPS-MIB::xupsRecepIndex.X; Value (Integer): X */
+	{ "outlet.%i.id", 0, 1, ".1.3.6.1.4.1.534.1.12.2.1.1.%i", NULL, SU_FLAG_STATIC | SU_OUTLET, NULL },
+	/* This MIB does not provide outlets switchability info. So map to a nearby
+		OID, for data activation, and map all values to "yes" */
+	{ "outlet.%i.switchable", 0, 1, ".1.3.6.1.4.1.534.1.12.2.1.1.%i", NULL, SU_FLAG_STATIC | SU_OUTLET, NULL },
+	/* XUPS-MIB::xupsRecepStatus.X; Value (Integer): 1 */
+	{ "outlet.%i.status", 0, 1, ".1.3.6.1.4.1.534.1.12.2.1.2.%i", NULL, SU_OUTLET, &pw_outlet_status_info[0] },
 
 	/* Ambient collection */
 	/* EMP001 (legacy) mapping */
@@ -623,16 +645,36 @@ static snmp_info_t pw_mib[] = {
 	/* Cancel output off, by writing 0 to xupsControlOutputOffDelay */
 	{ "shutdown.stop", 0, 0, PW_OID_CONT_OFFDELAY, "",
 		SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	/* XUPS-MIB::xupsControlOutputOffDelay */
 	/* load off after 1 sec, shortest possible delay; 0 cancels */
-	{ "load.off", 0, 1, PW_OID_CONT_OFFDELAY, "",
+	{ "load.off", 0, 1, PW_OID_CONT_OFFDELAY, "1",
 		SU_TYPE_CMD | SU_FLAG_OK, NULL },
-	{ "load.off.delay", 0, DEFAULT_OFFDELAY, PW_OID_CONT_OFFDELAY, "",
+	/* Delayed version, parameter is mandatory (so dfl is NULL)! */
+	{ "load.off.delay", 0, 1, PW_OID_CONT_OFFDELAY, NULL,
 		SU_TYPE_CMD | SU_FLAG_OK, NULL },
+	/* XUPS-MIB::xupsControlOutputOnDelay */
 	/* load on after 1 sec, shortest possible delay; 0 cancels */
-	{ "load.on", 0, 1, PW_OID_CONT_ONDELAY, "",
+	{ "load.on", 0, 1, PW_OID_CONT_ONDELAY, "1",
 		SU_TYPE_CMD | SU_FLAG_OK, NULL },
-	{ "load.on.delay", 0, DEFAULT_ONDELAY, PW_OID_CONT_ONDELAY, "",
+	/* Delayed version, parameter is mandatory (so dfl is NULL)! */
+	{ "load.on.delay", 0, 1, PW_OID_CONT_ONDELAY, NULL,
 		SU_TYPE_CMD | SU_FLAG_OK, NULL },
+
+	/* Delays handling:
+	 * 0-n :Time in seconds until the command is issued
+	 * -1:Cancel a pending Off/On command */
+	/* XUPS-MIB::xupsRecepOffDelaySecs.n */
+	{ "outlet.%i.load.off", 0, 1, ".1.3.6.1.4.1.534.1.12.2.1.3.%i",
+		"0", SU_TYPE_CMD | SU_OUTLET, NULL },
+	/* XUPS-MIB::xupsRecepOnDelaySecs.n */
+	{ "outlet.%i.load.on", 0, 1, ".1.3.6.1.4.1.534.1.12.2.1.4.%i",
+		"0", SU_TYPE_CMD | SU_OUTLET, NULL },
+	/* Delayed version, parameter is mandatory (so dfl is NULL)! */
+	{ "outlet.%i.load.off.delay", 0, 1, ".1.3.6.1.4.1.534.1.12.2.1.3.%i",
+		NULL, SU_TYPE_CMD | SU_OUTLET, NULL },
+	/* XUPS-MIB::xupsRecepOnDelaySecs.n */
+	{ "outlet.%i.load.on.delay", 0, 1, ".1.3.6.1.4.1.534.1.12.2.1.4.%i",
+		NULL, SU_TYPE_CMD | SU_OUTLET, NULL },
 
 	{ "ups.alarms", 0, 1.0, PW_OID_ALARMS, "",
 		0, NULL },

--- a/drivers/rhino.c
+++ b/drivers/rhino.c
@@ -305,7 +305,7 @@ ScanReceivePack( void )
   if(  !( SourceFail ) && !( RedeAnterior ) ) /* retorno da rede */
     RetornoDaRede = true;
   
-  if( !( SourceFail ) == RedeAnterior )
+  if( (! SourceFail ) == RedeAnterior )
     {
       RetornoDaRede = false;
       OcorrenciaDeFalha = false;

--- a/scripts/DMF/dmfsnmp/powerware-mib.dmf
+++ b/scripts/DMF/dmfsnmp/powerware-mib.dmf
@@ -1,5 +1,13 @@
 <?xml version="1.0" ?>
 <nut version="1.0.0" xmlns="http://www.networkupstools.org/dmf/snmp/snmp-ups">
+	<lookup name="pw_outlet_status_info">
+		<lookup_info oid="1" value="on"/>
+		<lookup_info oid="2" value="off"/>
+		<lookup_info oid="3" value="on"/>
+		<lookup_info oid="4" value="off"/>
+		<lookup_info oid="7" value="off"/>
+		<lookup_info oid="8" value="on"/>
+	</lookup>
 	<lookup name="pw_alarm_lb">
 		<lookup_info oid="1" value="LB"/>
 		<lookup_info oid="2" value=""/>
@@ -213,7 +221,7 @@
 		<snmp_info default="" multiplier="1.0" name="input.phases" oid="1.3.6.1.4.1.534.1.3.3.0" power_status="yes"/>
 		<snmp_info default="" multiplier="0.1" name="input.frequency" oid="1.3.6.1.4.1.534.1.3.1.0" power_status="yes"/>
 		<snmp_info default="" input_1_phase="yes" multiplier="1.0" name="input.voltage" oid="1.3.6.1.4.1.534.1.3.4.1.2.0"/>
-		<snmp_info default="" input_1_phase="yes" multiplier="1.0" name="input.voltage" oid="1.3.6.1.4.1.534.1.3.4.1.2.1.0"/>
+		<snmp_info default="" input_1_phase="yes" multiplier="1.0" name="input.voltage" oid="1.3.6.1.4.1.534.1.3.4.1.2.1"/>
 		<snmp_info default="" multiplier="1.0" name="input.voltage.nominal" oid="1.3.6.1.4.1.534.1.10.2.0" power_status="yes"/>
 		<snmp_info default="" input_1_phase="yes" multiplier="0.1" name="input.current" oid="1.3.6.1.4.1.534.1.3.4.1.3.0"/>
 		<snmp_info default="" input_3_phase="yes" multiplier="1.0" name="input.L1-N.voltage" oid="1.3.6.1.4.1.534.1.3.4.1.2.1"/>
@@ -232,6 +240,10 @@
 		<snmp_info default="" input_3_phase="yes" multiplier="1.0" name="input.bypass.L1-N.voltage" oid="1.3.6.1.4.1.534.1.5.3.1.2.1"/>
 		<snmp_info default="" input_3_phase="yes" multiplier="1.0" name="input.bypass.L2-N.voltage" oid="1.3.6.1.4.1.534.1.5.3.1.2.2"/>
 		<snmp_info default="" input_3_phase="yes" multiplier="1.0" name="input.bypass.L3-N.voltage" oid="1.3.6.1.4.1.534.1.5.3.1.2.3"/>
+		<snmp_info multiplier="1.0" name="outlet.count" oid=".1.3.6.1.4.1.534.1.12.1.0" static="yes"/>
+		<snmp_info multiplier="1.0" name="outlet.%i.id" oid=".1.3.6.1.4.1.534.1.12.2.1.1.%i" outlet="yes" static="yes"/>
+		<snmp_info multiplier="1.0" name="outlet.%i.switchable" oid=".1.3.6.1.4.1.534.1.12.2.1.1.%i" outlet="yes" static="yes"/>
+		<snmp_info lookup="pw_outlet_status_info" multiplier="1.0" name="outlet.%i.status" oid=".1.3.6.1.4.1.534.1.12.2.1.2.%i" outlet="yes"/>
 		<snmp_info default="" multiplier="1.0" name="ambient.temperature" oid="1.3.6.1.4.1.534.1.6.5.0" power_status="yes"/>
 		<snmp_info default="" multiplier="1.0" name="ambient.temperature.low" oid="1.3.6.1.4.1.534.1.6.9.0" power_status="yes" writable="yes"/>
 		<snmp_info default="" multiplier="1.0" name="ambient.temperature.high" oid="1.3.6.1.4.1.534.1.6.10.0" power_status="yes" writable="yes"/>
@@ -272,14 +284,18 @@
 		<snmp_info ambient="yes" default="" lookup="ambient_drycontacts_state_info" multiplier="1.0" name="ambient.%i.contacts.2.status" oid=".1.3.6.1.4.1.534.6.8.1.4.3.1.3.%i.2" string="yes"/>
 		<snmp_info command="yes" default="" flag_ok="yes" multiplier="1.0" name="test.battery.start.quick" oid="1.3.6.1.4.1.534.1.8.1"/>
 		<snmp_info command="yes" default="" flag_ok="yes" multiplier="0.0" name="shutdown.return" oid="1.3.6.1.4.1.534.1.9.6"/>
-		<snmp_info command="yes" default="" flag_ok="yes" multiplier="0.0" name="shutdown.stop" oid="1.3.6.1.4.1.534.1.9.1"/>
-		<snmp_info command="yes" default="" flag_ok="yes" multiplier="1.0" name="load.off" oid="1.3.6.1.4.1.534.1.9.1"/>
-		<snmp_info command="yes" default="" flag_ok="yes" multiplier="30.0" name="load.off.delay" oid="1.3.6.1.4.1.534.1.9.1"/>
-		<snmp_info command="yes" default="" flag_ok="yes" multiplier="1.0" name="load.on" oid="1.3.6.1.4.1.534.1.9.2"/>
-		<snmp_info command="yes" default="" flag_ok="yes" multiplier="20.0" name="load.on.delay" oid="1.3.6.1.4.1.534.1.9.2"/>
+		<snmp_info command="yes" default="" flag_ok="yes" multiplier="0.0" name="shutdown.stop" oid="1.3.6.1.4.1.534.1.9.1.0"/>
+		<snmp_info command="yes" default="1" flag_ok="yes" multiplier="1.0" name="load.off" oid="1.3.6.1.4.1.534.1.9.1.0"/>
+		<snmp_info command="yes" flag_ok="yes" multiplier="1.0" name="load.off.delay" oid="1.3.6.1.4.1.534.1.9.1.0"/>
+		<snmp_info command="yes" default="1" flag_ok="yes" multiplier="1.0" name="load.on" oid="1.3.6.1.4.1.534.1.9.2.0"/>
+		<snmp_info command="yes" flag_ok="yes" multiplier="1.0" name="load.on.delay" oid="1.3.6.1.4.1.534.1.9.2.0"/>
+		<snmp_info command="yes" default="0" multiplier="1.0" name="outlet.%i.load.off" oid=".1.3.6.1.4.1.534.1.12.2.1.3.%i" outlet="yes"/>
+		<snmp_info command="yes" default="0" multiplier="1.0" name="outlet.%i.load.on" oid=".1.3.6.1.4.1.534.1.12.2.1.4.%i" outlet="yes"/>
+		<snmp_info command="yes" multiplier="1.0" name="outlet.%i.load.off.delay" oid=".1.3.6.1.4.1.534.1.12.2.1.3.%i" outlet="yes"/>
+		<snmp_info command="yes" multiplier="1.0" name="outlet.%i.load.on.delay" oid=".1.3.6.1.4.1.534.1.12.2.1.4.%i" outlet="yes"/>
 		<snmp_info default="" multiplier="1.0" name="ups.alarms" oid="1.3.6.1.4.1.534.1.7.1.0" power_status="yes"/>
 	</snmp>
-	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pw" name="powerware" oid=".1.3.6.1.4.1.534.1" snmp_info="pw_mib" version="0.97"/>
-	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pxgx_ups" name="pxgx_ups" oid=".1.3.6.1.4.1.534.2.12" snmp_info="pw_mib" version="0.97"/>
+	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pw" name="powerware" oid=".1.3.6.1.4.1.534.1" snmp_info="pw_mib" version="0.98"/>
+	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pxgx_ups" name="pxgx_ups" oid=".1.3.6.1.4.1.534.2.12" snmp_info="pw_mib" version="0.98"/>
 </nut>
 


### PR DESCRIPTION
* fix reading of input.voltage, related to the ending ".0",
* fix existing commands handling,
* add support for the load segment (managed outlets), including
status information and commands

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>