### PR TITLE
Problem: welcome screen is flooded by systemd logs

### DIFF
--- a/scripts/systemd/nut-server.service.in
+++ b/scripts/systemd/nut-server.service.in
@@ -13,7 +13,9 @@ Wants=nut-driver.target
 #   [Unit]
 #   Requires=network-online.target
 #   After=network-online.target
-Requires=network.target
+Requires=network.target fty-license-accepted.service
+BindsTo=fty-license-accepted.service
+After=fty-license-accepted.service
 Before=nut-monitor.service
 PartOf=nut.target
 


### PR DESCRIPTION
Solution: bind nut-server to EULA acceptance

Note: this happen prior to the EULA accepted, which makes it
impossible to configure static IP address, to be then able to
access the system UI

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>