### PR TITLE
snmp-ups: add Eaton ATS16 with new Network-M2

### DIFF
--- a/drivers/eaton-ats16-mib.c
+++ b/drivers/eaton-ats16-mib.c
@@ -2,7 +2,7 @@
  *
  *  Copyright (C)
  *    2011-2012 Arnaud Quette <arnaud.quette@free.fr>
- *    2016-2019 Eaton (author: Arnaud Quette <ArnaudQuette@Eaton.com>)
+ *    2016-2020 Eaton (author: Arnaud Quette <ArnaudQuette@Eaton.com>)
  *
  *  Note: this subdriver was initially generated as a "stub" by the
  *  gen-snmp-subdriver script. It must be customized!
@@ -24,9 +24,10 @@
 
 #include "eaton-ats16-mib.h"
 
-#define EATON_ATS16_MIB_VERSION  "0.18"
+#define EATON_ATS16_MIB_VERSION  "0.19"
 
-#define EATON_ATS16_SYSOID       ".1.3.6.1.4.1.534.10"
+#define EATON_ATS16_SYSOID_GEN1  ".1.3.6.1.4.1.705.1"    /* legacy NMC */
+#define EATON_ATS16_SYSOID_GEN2  ".1.3.6.1.4.1.534.10.2" /* newer Network-M2 */
 #define EATON_ATS16_MODEL        ".1.3.6.1.4.1.534.10.2.1.2.0"
 
 static info_lkp_t eaton_ats16_source_info[] = {
@@ -257,6 +258,11 @@ static snmp_info_t eaton_ats16_mib[] = {
 	{ NULL, 0, 0, NULL, NULL, 0, NULL }
 };
 
-mib2nut_info_t	eaton_ats16 = { "eaton_ats16", EATON_ATS16_MIB_VERSION, NULL, EATON_ATS16_MODEL, eaton_ats16_mib, ".1.3.6.1.4.1.705.1" };
-/* FIXME: Eaton ATS need to be fixed for the sysOID (currently .1.3.6.1.4.1.705.1!) */
-/* mib2nut_info_t	eaton_ats16 = { "eaton_ats16", EATON_ATS16_MIB_VERSION, NULL, EATON_ATS16_MODEL, eaton_ats16_mib, EATON_ATS16_SYSOID }; */
+/* Note: keep the legacy definition intact, to avoid breaking compatibility */
+mib2nut_info_t	eaton_ats16 = { "eaton_ats16", EATON_ATS16_MIB_VERSION, NULL, EATON_ATS16_MODEL, eaton_ats16_mib, EATON_ATS16_SYSOID_GEN1 };
+mib2nut_info_t	eaton_ats16_g2 = { "eaton_ats16_g2", EATON_ATS16_MIB_VERSION, NULL, EATON_ATS16_MODEL, eaton_ats16_mib, EATON_ATS16_SYSOID_GEN2 };
+/* Note:
+ * * newer Network-M2 communication cards, with a fixed sysOID (above)
+ * * due to a bug in tools/nut-snmpinfo.py, prepending a 2nd mib2nut_info_t declaration with a comment line
+ *   results in data extraction not being done for all entries in the file. Hence the above comment line being
+ *   after its belonging declaration! */

--- a/drivers/eaton-ats16-mib.h
+++ b/drivers/eaton-ats16-mib.h
@@ -26,5 +26,6 @@
 #include "snmp-ups.h"
 
 extern mib2nut_info_t eaton_ats16;
+extern mib2nut_info_t eaton_ats16_g2;
 
 #endif /* EATON_ATS16_MIB_H */

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -113,6 +113,7 @@ static mib2nut_info_t *mib2nut[] = {
 	&cyberpower,		/* This struct comes from : cyberpower-mib.c */
 	&delta_ups,			/* This struct comes from : delta_ups-mib.c */
 	&eaton_ats16,		/* This struct comes from : eaton-ats16-mib.c */
+	&eaton_ats16_g2,	/* This struct comes from : eaton-ats16-mib.c */
 	&eaton_ats30,		/* This struct comes from : eaton-ats30-mib.c */
 	&eaton_marlin,		/* This struct comes from : eaton-mib.c */
 	&emerson_avocent_pdu,	/* This struct comes from : emerson-avocent-pdu-mib.c */
@@ -167,7 +168,7 @@ const char *mibvers;
 #else
 # define DRIVER_NAME	"Generic SNMP UPS driver"
 #endif /* WITH_DMFMIB */
-#define DRIVER_VERSION		"1.13"
+#define DRIVER_VERSION		"1.14"
 
 /* driver description structure */
 upsdrv_info_t	upsdrv_info = {

--- a/scripts/DMF/dmfnutscan/dmfnutscan-snmp.dmf
+++ b/scripts/DMF/dmfnutscan/dmfnutscan-snmp.dmf
@@ -23,6 +23,7 @@
 	<mib2nut auto_check=".1.3.6.1.4.1.4779.1.3.5.2.1.24.1" mib_name="baytech" />
 	<mib2nut auto_check=".1.3.6.1.4.1.534.10.1.2.1.0" mib_name="eaton_ats30" oid=".1.3.6.1.4.1.534.10.1" />
 	<mib2nut auto_check=".1.3.6.1.4.1.534.10.2.1.2.0" mib_name="eaton_ats16" oid=".1.3.6.1.4.1.705.1" />
+	<mib2nut auto_check=".1.3.6.1.4.1.534.10.2.1.2.0" mib_name="eaton_ats16_g2" oid=".1.3.6.1.4.1.534.10.2" />
 	<mib2nut auto_check=".1.3.6.1.4.1.534.6.6.6.1.1.12.0" mib_name="aphel_revelation" oid=".1.3.6.1.4.1.534.6.6.6" />
 	<mib2nut auto_check=".1.3.6.1.4.1.534.6.6.7.1.2.1.2.0" mib_name="eaton_epdu" oid=".1.3.6.1.4.1.534.6.6.7" />
 	<mib2nut auto_check=".1.3.6.1.4.1.705.1.1.1.0" mib_name="mge" oid=".1.3.6.1.4.1.705.1" />

--- a/scripts/DMF/dmfsnmp/eaton-ats16-mib.dmf
+++ b/scripts/DMF/dmfsnmp/eaton-ats16-mib.dmf
@@ -79,6 +79,7 @@
 		<snmp_info flag_ok="yes" lookup="eaton_ats16_ambient_drycontacts_info" multiplier="128.0" name="ambient.contacts.1.status" oid=".1.3.6.1.4.1.534.10.2.5.4.1.3.1" string="yes"/>
 		<snmp_info flag_ok="yes" lookup="eaton_ats16_ambient_drycontacts_info" multiplier="128.0" name="ambient.contacts.2.status" oid=".1.3.6.1.4.1.534.10.2.5.4.1.3.2" string="yes"/>
 	</snmp>
-	<mib2nut auto_check=".1.3.6.1.4.1.534.10.2.1.2.0" mib_name="eaton_ats16" name="eaton_ats16" oid=".1.3.6.1.4.1.705.1" snmp_info="eaton_ats16_mib" version="0.18"/>
+	<mib2nut auto_check=".1.3.6.1.4.1.534.10.2.1.2.0" mib_name="eaton_ats16" name="eaton_ats16" oid=".1.3.6.1.4.1.705.1" snmp_info="eaton_ats16_mib" version="0.19"/>
+	<mib2nut auto_check=".1.3.6.1.4.1.534.10.2.1.2.0" mib_name="eaton_ats16_g2" name="eaton_ats16" oid=".1.3.6.1.4.1.534.10.2" snmp_info="eaton_ats16_mib" version="0.19"/>
 </nut>
 

--- a/scripts/DMF/dmfsnmp/eaton-ats16-mib.dmf
+++ b/scripts/DMF/dmfsnmp/eaton-ats16-mib.dmf
@@ -80,6 +80,6 @@
 		<snmp_info flag_ok="yes" lookup="eaton_ats16_ambient_drycontacts_info" multiplier="128.0" name="ambient.contacts.2.status" oid=".1.3.6.1.4.1.534.10.2.5.4.1.3.2" string="yes"/>
 	</snmp>
 	<mib2nut auto_check=".1.3.6.1.4.1.534.10.2.1.2.0" mib_name="eaton_ats16" name="eaton_ats16" oid=".1.3.6.1.4.1.705.1" snmp_info="eaton_ats16_mib" version="0.19"/>
-	<mib2nut auto_check=".1.3.6.1.4.1.534.10.2.1.2.0" mib_name="eaton_ats16_g2" name="eaton_ats16" oid=".1.3.6.1.4.1.534.10.2" snmp_info="eaton_ats16_mib" version="0.19"/>
+	<mib2nut auto_check=".1.3.6.1.4.1.534.10.2.1.2.0" mib_name="eaton_ats16_g2" name="eaton_ats16_g2" oid=".1.3.6.1.4.1.534.10.2" snmp_info="eaton_ats16_mib" version="0.19"/>
 </nut>
 


### PR DESCRIPTION
Add support for Eaton ATS16 using the new Network-M2 communication cards,
and including a fixed sysOID fingerprint

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>
(cherry picked from commit 88c79e245038e1cad9debd46f725016147bd5474)
Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>

Also update DMF files