### PR TITLE
Allow to configure ALLOW_NO_DEVICE (nee NUT_NOCONF_ALLOWED) option via upsd.conf

### DIFF
--- a/conf/nut.conf.sample
+++ b/conf/nut.conf.sample
@@ -31,6 +31,7 @@
 
 MODE=none
 
-# Uncomment this to allow starting the service even if ups.conf has
-# no device sections at the moment:
+# Uncomment this to allow starting the service even if ups.conf has no device
+# sections at the moment. This environment variable overrides the built-in
+# "false" and an optional same-named default flag that can be set in upsd.conf:
 NUT_NOCONF_ALLOWED=true; export NUT_NOCONF_ALLOWED

--- a/conf/nut.conf.sample
+++ b/conf/nut.conf.sample
@@ -34,4 +34,4 @@ MODE=none
 # Uncomment this to allow starting the service even if ups.conf has no device
 # sections at the moment. This environment variable overrides the built-in
 # "false" and an optional same-named default flag that can be set in upsd.conf:
-NUT_NOCONF_ALLOWED=true; export NUT_NOCONF_ALLOWED
+ALLOW_NO_DEVICE=true; export ALLOW_NO_DEVICE

--- a/conf/upsd.conf.sample
+++ b/conf/upsd.conf.sample
@@ -30,6 +30,21 @@
 # amount of time, and then cleaned up.
 
 # =======================================================================
+# NUT_NOCONF_ALLOWED <bool>
+# NUT_NOCONF_ALLOWED true
+#
+# Normally upsd requires that at least one device section is defined in ups.conf
+# when the daemon starts, to serve its data.  For automatically managed services
+# it may be preferred to have upsd always running, and reload the configuration
+# when power devices become defined.
+#
+# Boolean values 'true', 'yes', 'on' and '1' mean that the server would not
+# refuse to start with zero device sections found in ups.conf.
+#
+# Boolean values 'false', 'no', 'off' and '0' mean that the server should refuse
+# to start if zero device sections were found in ups.conf. This is the default.
+
+# =======================================================================
 # STATEPATH <path>
 # STATEPATH /var/run/nut
 #

--- a/conf/upsd.conf.sample
+++ b/conf/upsd.conf.sample
@@ -30,7 +30,7 @@
 # amount of time, and then cleaned up.
 
 # =======================================================================
-# NUT_NOCONF_ALLOWED <bool>
+# NUT_NOCONF_ALLOWED <Boolean>
 # NUT_NOCONF_ALLOWED true
 #
 # Normally upsd requires that at least one device section is defined in ups.conf

--- a/conf/upsd.conf.sample
+++ b/conf/upsd.conf.sample
@@ -30,8 +30,8 @@
 # amount of time, and then cleaned up.
 
 # =======================================================================
-# NUT_NOCONF_ALLOWED <Boolean>
-# NUT_NOCONF_ALLOWED true
+# ALLOW_NO_DEVICE <Boolean>
+# ALLOW_NO_DEVICE true
 #
 # Normally upsd requires that at least one device section is defined in ups.conf
 # when the daemon starts, to serve its data.  For automatically managed services

--- a/docs/man/upsd.conf.txt
+++ b/docs/man/upsd.conf.txt
@@ -32,6 +32,19 @@ When instant commands and variables setting status tracking is enabled, status
 execution information are kept during this amount of time, and then cleaned up.
 This defaults to 3600 (1 hour).
 
+"NUT_NOCONF_ALLOWED 'bool'"::
+
+Normally upsd requires that at least one device section is defined in ups.conf
+when the daemon starts, to serve its data.  For automatically managed services
+it may be preferred to have upsd always running, and reload the configuration
+when power devices become defined.
++
+Boolean values 'true', 'yes', 'on' and '1' mean that the server would not
+refuse to start with zero device sections found in ups.conf.
++
+Boolean values 'false', 'no', 'off' and '0' mean that the server should refuse
+to start if zero device sections were found in ups.conf. This is the default.
+
 "STATEPATH 'path'"::
 
 Tell upsd to look for the driver state sockets in 'path' rather

--- a/docs/man/upsd.conf.txt
+++ b/docs/man/upsd.conf.txt
@@ -32,7 +32,7 @@ When instant commands and variables setting status tracking is enabled, status
 execution information are kept during this amount of time, and then cleaned up.
 This defaults to 3600 (1 hour).
 
-"NUT_NOCONF_ALLOWED 'Boolean'"::
+"ALLOW_NO_DEVICE 'Boolean'"::
 
 Normally upsd requires that at least one device section is defined in ups.conf
 when the daemon starts, to serve its data.  For automatically managed services

--- a/docs/man/upsd.conf.txt
+++ b/docs/man/upsd.conf.txt
@@ -32,7 +32,7 @@ When instant commands and variables setting status tracking is enabled, status
 execution information are kept during this amount of time, and then cleaned up.
 This defaults to 3600 (1 hour).
 
-"NUT_NOCONF_ALLOWED 'bool'"::
+"NUT_NOCONF_ALLOWED 'Boolean'"::
 
 Normally upsd requires that at least one device section is defined in ups.conf
 when the daemon starts, to serve its data.  For automatically managed services

--- a/scripts/augeas/nutupsdconf.aug.in
+++ b/scripts/augeas/nutupsdconf.aug.in
@@ -52,13 +52,14 @@ let upsd_certfile = [ opt_spc . key "CERTFILE" . sep_spc . store path . eol ]
 (************************************************************************
  * MAXAGE seconds
  * TRACKINGDELAY seconds
+ * ALLOW_NO_DEVICE Boolean
  * STATEPATH path
  * LISTEN interface port
  *    Multiple LISTEN addresses may be specified. The default is to bind to 0.0.0.0 if no LISTEN addresses are specified.
  *    LISTEN 127.0.0.1 LISTEN 192.168.50.1 LISTEN ::1 LISTEN 2001:0db8:1234:08d3:1319:8a2e:0370:7344
  *
  *************************************************************************)
-let upsd_other  =  upsd_maxage | upsd_trackingdelay | upsd_statepath | upsd_listen_list | upsd_maxconn | upsd_certfile
+let upsd_other  =  upsd_maxage | upsd_trackingdelay | upsd_allow_no_device | upsd_statepath | upsd_listen_list | upsd_maxconn | upsd_certfile
 
 let upsd_lns    = (upsd_other|comment|empty)*
 

--- a/scripts/augeas/nutupsdconf.aug.in
+++ b/scripts/augeas/nutupsdconf.aug.in
@@ -40,7 +40,7 @@ let path     = word
 
 let upsd_maxage    = [ opt_spc . key "MAXAGE"    . sep_spc . store num  . eol ]
 let upsd_trackingdelay = [ opt_spc . key "TRACKINGDELAY"    . sep_spc . store num  . eol ]
-let upsd_nut_noconf_allowed = [ opt_spc . key "NUT_NOCONF_ALLOWED"    . sep_spc . store num  . eol ]
+let upsd_allow_no_device = [ opt_spc . key "ALLOW_NO_DEVICE"    . sep_spc . store num  . eol ]
 let upsd_statepath = [ opt_spc . key "STATEPATH" . sep_spc . store path . eol ]
 let upsd_listen    = [ opt_spc . key "LISTEN"    . sep_spc 
                           . [ label "interface" . store ip ]

--- a/scripts/augeas/nutupsdconf.aug.in
+++ b/scripts/augeas/nutupsdconf.aug.in
@@ -40,6 +40,7 @@ let path     = word
 
 let upsd_maxage    = [ opt_spc . key "MAXAGE"    . sep_spc . store num  . eol ]
 let upsd_trackingdelay = [ opt_spc . key "TRACKINGDELAY"    . sep_spc . store num  . eol ]
+let upsd_nut_noconf_allowed = [ opt_spc . key "NUT_NOCONF_ALLOWED"    . sep_spc . store num  . eol ]
 let upsd_statepath = [ opt_spc . key "STATEPATH" . sep_spc . store path . eol ]
 let upsd_listen    = [ opt_spc . key "LISTEN"    . sep_spc 
                           . [ label "interface" . store ip ]

--- a/scripts/augeas/tests/test_nut.aug
+++ b/scripts/augeas/tests/test_nut.aug
@@ -28,6 +28,7 @@ test NutUpsConf.ups_lns get ups_conf =
 let upsd_conf = "
 MAXAGE 30
 TRACKINGDELAY 600
+NUT_NOCONF_ALLOWED 1
 LISTEN 0.0.0.0 3493
 MAXCONN 1024
 "
@@ -36,6 +37,7 @@ test NutUpsdConf.upsd_lns get upsd_conf =
 	{ }
 	{ "MAXAGE"      = "30" }
 	{ "TRACKINGDELAY" = "600" }
+	{ "NUT_NOCONF_ALLOWED" = "1" }
 	{ "LISTEN"
 		{ "interface" = "0.0.0.0" }
 		{ "port"     = "3493"     } }

--- a/scripts/augeas/tests/test_nut.aug
+++ b/scripts/augeas/tests/test_nut.aug
@@ -28,7 +28,7 @@ test NutUpsConf.ups_lns get ups_conf =
 let upsd_conf = "
 MAXAGE 30
 TRACKINGDELAY 600
-NUT_NOCONF_ALLOWED 1
+ALLOW_NO_DEVICE 1
 LISTEN 0.0.0.0 3493
 MAXCONN 1024
 "
@@ -37,7 +37,7 @@ test NutUpsdConf.upsd_lns get upsd_conf =
 	{ }
 	{ "MAXAGE"      = "30" }
 	{ "TRACKINGDELAY" = "600" }
-	{ "NUT_NOCONF_ALLOWED" = "1" }
+	{ "ALLOW_NO_DEVICE" = "1" }
 	{ "LISTEN"
 		{ "interface" = "0.0.0.0" }
 		{ "port"     = "3493"     } }

--- a/server/conf.c
+++ b/server/conf.c
@@ -144,6 +144,26 @@ static int parse_upsd_conf_args(int numargs, char **arg)
 		}
 	}
 
+	/* NUT_NOCONF_ALLOWED <seconds> */
+	if (!strcmp(arg[0], "NUT_NOCONF_ALLOWED")) {
+		if (isdigit(arg[1][0])) {
+			nut_noconf_allowed = (atoi(arg[1]) != 0); // non-zero arg is true here
+			return 1;
+		}
+		else {
+			if ( (!strcasecmp(arg[1], "true")) || (!strcasecmp(arg[1], "on")) || (!strcasecmp(arg[1], "yes"))) {
+				nut_noconf_allowed = 1;
+				return 1;
+			}
+			if ( (!strcasecmp(arg[1], "false")) || (!strcasecmp(arg[1], "off")) || (!strcasecmp(arg[1], "no"))) {
+				nut_noconf_allowed = 0;
+				return 1;
+			}
+			upslogx(LOG_ERR, "NUT_NOCONF_ALLOWED has non numeric and non boolean value (%s)!", arg[1]);
+			return 0;
+		}
+	}
+
 	/* MAXCONN <connections> */
 	if (!strcmp(arg[0], "MAXCONN")) {
 		if (isdigit(arg[1][0])) {

--- a/server/conf.c
+++ b/server/conf.c
@@ -144,22 +144,22 @@ static int parse_upsd_conf_args(int numargs, char **arg)
 		}
 	}
 
-	/* NUT_NOCONF_ALLOWED <seconds> */
-	if (!strcmp(arg[0], "NUT_NOCONF_ALLOWED")) {
+	/* ALLOW_NO_DEVICE <seconds> */
+	if (!strcmp(arg[0], "ALLOW_NO_DEVICE")) {
 		if (isdigit(arg[1][0])) {
-			nut_noconf_allowed = (atoi(arg[1]) != 0); // non-zero arg is true here
+			allow_no_device = (atoi(arg[1]) != 0); // non-zero arg is true here
 			return 1;
 		}
 		else {
 			if ( (!strcasecmp(arg[1], "true")) || (!strcasecmp(arg[1], "on")) || (!strcasecmp(arg[1], "yes"))) {
-				nut_noconf_allowed = 1;
+				allow_no_device = 1;
 				return 1;
 			}
 			if ( (!strcasecmp(arg[1], "false")) || (!strcasecmp(arg[1], "off")) || (!strcasecmp(arg[1], "no"))) {
-				nut_noconf_allowed = 0;
+				allow_no_device = 0;
 				return 1;
 			}
-			upslogx(LOG_ERR, "NUT_NOCONF_ALLOWED has non numeric and non boolean value (%s)!", arg[1]);
+			upslogx(LOG_ERR, "ALLOW_NO_DEVICE has non numeric and non boolean value (%s)!", arg[1]);
 			return 0;
 		}
 	}

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -58,10 +58,10 @@ int	deny_severity = LOG_WARNING;
 	int	tracking_delay = 3600;
 
 	/*
-	 * Preloaded to NUT_NOCONF_ALLOWED from upsd.conf or environment variable
+	 * Preloaded to ALLOW_NO_DEVICE from upsd.conf or environment variable
 	 * (with higher prio for envvar); defaults to disabled for legacy compat.
 	 */
-	int nut_noconf_allowed = 0;
+	int allow_no_device = 0;
 
 	/* preloaded to {OPEN_MAX} in main, can be overridden via upsd.conf */
 	int	maxconn = 0;
@@ -1259,23 +1259,23 @@ int main(int argc, char **argv)
 	load_upsdconf(0);	/* 0 = initial */
 
 	{ // scope
-	/* As documented above, the NUT_NOCONF_ALLOWED can be provided via
+	/* As documented above, the ALLOW_NO_DEVICE can be provided via
 	 * envvars and then has higher priority than an upsd.conf setting
 	 */
-	const char *envvar = getenv("NUT_NOCONF_ALLOWED");
+	const char *envvar = getenv("ALLOW_NO_DEVICE");
 	if ( envvar != NULL) {
 		if ( (!strncasecmp("TRUE", envvar, 4)) || (!strncasecmp("YES", envvar, 3)) || (!strncasecmp("ON", envvar, 2)) || (!strncasecmp("1", envvar, 1)) ) {
 			/* Admins of this server expressed a desire to serve
 			 * anything on the NUT protocol, even if nothing is
 			 * configured yet - tell the clients so, properly.
 			 */
-			nut_noconf_allowed = 1;
+			allow_no_device = 1;
 		} else if ( (!strncasecmp("FALSE", envvar, 5)) || (!strncasecmp("NO", envvar, 2)) || (!strncasecmp("OFF", envvar, 3)) || (!strncasecmp("0", envvar, 1)) ) {
 			/* Admins of this server expressed a desire to serve
 			 * anything on the NUT protocol, even if nothing is
 			 * configured yet - tell the clients so, properly.
 			 */
-			nut_noconf_allowed = 0;
+			allow_no_device = 0;
 		}
 	}
 	} // scope
@@ -1298,7 +1298,7 @@ int main(int argc, char **argv)
 	poll_reload();
 
 	if (num_ups == 0) {
-		if (nut_noconf_allowed) {
+		if (allow_no_device) {
 			upslogx(LOG_WARNING, "Normally at least one UPS must be defined in ups.conf, currently there are none (please configure the file and reload the service)");
 		} else {
 			fatalx(EXIT_FAILURE, "Fatal error: at least one UPS must be defined in ups.conf");

--- a/server/upsd.c
+++ b/server/upsd.c
@@ -1262,7 +1262,7 @@ int main(int argc, char **argv)
 	/* As documented above, the NUT_NOCONF_ALLOWED can be provided via
 	 * envvars and then has higher priority than an upsd.conf setting
 	 */
-	char *envvar = getenv("NUT_NOCONF_ALLOWED");
+	const char *envvar = getenv("NUT_NOCONF_ALLOWED");
 	if ( envvar != NULL) {
 		if ( (!strncasecmp("TRUE", envvar, 4)) || (!strncasecmp("YES", envvar, 3)) || (!strncasecmp("ON", envvar, 2)) || (!strncasecmp("1", envvar, 1)) ) {
 			/* Admins of this server expressed a desire to serve

--- a/server/upsd.h
+++ b/server/upsd.h
@@ -90,7 +90,7 @@ int tracking_disable(void);
 int tracking_is_enabled(void);
 
 /* declarations from upsd.c */
-extern int		maxage, maxconn, tracking_delay, nut_noconf_allowed;
+extern int		maxage, maxconn, tracking_delay, allow_no_device;
 extern char		*statepath, *datapath;
 extern upstype_t	*firstups;
 extern nut_ctype_t	*firstclient;

--- a/server/upsd.h
+++ b/server/upsd.h
@@ -90,8 +90,7 @@ int tracking_disable(void);
 int tracking_is_enabled(void);
 
 /* declarations from upsd.c */
-
-extern int		maxage, maxconn, tracking_delay;
+extern int		maxage, maxconn, tracking_delay, nut_noconf_allowed;
 extern char		*statepath, *datapath;
 extern upstype_t	*firstups;
 extern nut_ctype_t	*firstclient;


### PR DESCRIPTION
Follow-up from #102 

Tested to support different ways of spelling the boolean setting in upsd.conf and in envvar as supported (and with higher priority) per original PR.