### PR TITLE
Fix faulty dump mode logic

### DIFF
--- a/drivers/main.c
+++ b/drivers/main.c
@@ -744,9 +744,10 @@ int main(int argc, char **argv)
 			else
 				update_count++;
 		}
-
-		while (!dstate_poll_fds(timeout, extrafd) && !exit_flag) {
-			/* repeat until time is up or extrafd has data */
+		else {
+			while (!dstate_poll_fds(timeout, extrafd) && !exit_flag) {
+				/* repeat until time is up or extrafd has data */
+			}
 		}
 	}
 


### PR DESCRIPTION
NUT drivers in dump mode are now crashing with buffer overflows unless this specific section of code is reverted:
```
admin@eaton-rc-0050568CAEA8:~$ /lib/nut/snmp-ups -s test -d 2 -x port=10.130.32.120
Network UPS Tools - Generic SNMP UPS driver (DMF) 1.14 (2.7.4.1)
Detected Eaton 9PX 8000i on host 10.130.32.120 (mib: pw 0.98)
*** buffer overflow detected ***: /lib/nut/snmp-ups terminated
Aborted
admin@eaton-rc-0050568CAEA8:~$ 
```

This has been root-caused to a faulty modification of dump mode logic.