### PR TITLE
snmp-ups: fix instant commands using numeric parameters

### DIFF
--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -5,7 +5,7 @@
  *
  *  Copyright (C)
  *	2002 - 2014	Arnaud Quette <arnaud.quette@free.fr>
- *	2015 - 2019	Eaton (author: Arnaud Quette <ArnaudQuette@Eaton.com>)
+ *	2015 - 2021	Eaton (author: Arnaud Quette <ArnaudQuette@Eaton.com>)
  *	2016 - 2019	Eaton (author: Jim Klimov <EvgenyKlimov@Eaton.com>)
  *	2016		Eaton (author: Carlos Dominguez <CarlosDominguez@Eaton.com>)
  *	2002 - 2006	Dmitry Frolov <frolov@riss-telecom.ru>
@@ -170,7 +170,7 @@ const char *mibvers;
 #else
 # define DRIVER_NAME	"Generic SNMP UPS driver"
 #endif /* WITH_DMFMIB */
-#define DRIVER_VERSION		"1.14"
+#define DRIVER_VERSION		"1.15"
 
 /* driver description structure */
 upsdrv_info_t	upsdrv_info = {
@@ -3225,7 +3225,7 @@ int su_setOID(int mode, const char *varname, const char *val)
 			}
 		}
 		/* Actually apply the new value */
-		if (su_info_p->flags & SU_TYPE_TIME) {
+		if (SU_TYPE(su_info_p) == SU_TYPE_TIME) {
 			status = nut_snmp_set_time(su_info_p->OID, value);
 		}
 		else {


### PR DESCRIPTION
Instants commands using numeric parameters, like on/off/cycle
commands, were failing due to a bad value submitted type (time
instead of integer)

Signed-off-by: Arnaud Quette <ArnaudQuette@eaton.com>

Ref: IPMVAL-2198