### PR TITLE
snmp-ups: fix regression on Eaton ePDU

### DIFF
--- a/drivers/eaton-pdu-marlin-mib.c
+++ b/drivers/eaton-pdu-marlin-mib.c
@@ -36,7 +36,7 @@
 /* Eaton PDU-MIB - Marlin MIB
  * ************************** */
 
-#define EATON_MARLIN_MIB_VERSION	"0.56"
+#define EATON_MARLIN_MIB_VERSION	"0.57"
 #define EATON_MARLIN_SYSOID			".1.3.6.1.4.1.534.6.6.7"
 #define EATON_MARLIN_OID_MODEL_NAME	".1.3.6.1.4.1.534.6.6.7.1.2.1.2.0"
 
@@ -1375,7 +1375,7 @@ static snmp_info_t eaton_marlin_mib[] = {
 	/* Ugly hack for older G2 ePDU: check the first outlet to determine unit switchability */
 	{ "outlet.switchable", ST_FLAG_STRING, SU_INFOSIZE,
 		".1.3.6.1.4.1.534.6.6.7.6.6.1.3.%i.1",
-		"no", SU_FLAG_STATIC | SU_FLAG_UNIQUE | SU_OUTLET | SU_FLAG_OK | SU_TYPE_DAISY_1, &g2_unit_outlet_switchability_info[0] },
+		"no", SU_FLAG_STATIC | SU_FLAG_UNIQUE | SU_FLAG_OK | SU_TYPE_DAISY_1, &g2_unit_outlet_switchability_info[0] },
 	/* The below ones are the same as the input.* equivalent */
 	/* FIXME: transition period, TO BE REMOVED, moved to input.* */
 	{ "outlet.frequency", 0, 0.1, ".1.3.6.1.4.1.534.6.6.7.3.1.1.3.%i.1",

--- a/scripts/DMF/dmfsnmp/eaton-pdu-marlin-mib.dmf
+++ b/scripts/DMF/dmfsnmp/eaton-pdu-marlin-mib.dmf
@@ -293,7 +293,7 @@
 		<snmp_info absent="yes" default="0" flag_ok="yes" multiplier="1.0" name="outlet.id" static="yes"/>
 		<snmp_info absent="yes" default="All outlets" flag_ok="yes" multiplier="20.0" name="outlet.desc" static="yes" string="yes" writable="yes"/>
 		<snmp_info default="no" lookup="marlin_unit_switchability_info" multiplier="128.0" name="outlet.switchable" oid=".1.3.6.1.4.1.534.6.6.7.1.2.1.10.%i" static="yes" string="yes" unique="yes"/>
-		<snmp_info default="no" flag_ok="yes" lookup="g2_unit_outlet_switchability_info" multiplier="128.0" name="outlet.switchable" oid=".1.3.6.1.4.1.534.6.6.7.6.6.1.3.%i.1" outlet="yes" static="yes" string="yes" type_daisy="1" unique="yes"/>
+		<snmp_info default="no" flag_ok="yes" lookup="g2_unit_outlet_switchability_info" multiplier="128.0" name="outlet.switchable" oid=".1.3.6.1.4.1.534.6.6.7.6.6.1.3.%i.1" static="yes" string="yes" type_daisy="1" unique="yes"/>
 		<snmp_info multiplier="0.1" name="outlet.frequency" oid=".1.3.6.1.4.1.534.6.6.7.3.1.1.3.%i.1" power_status="yes"/>
 		<snmp_info multiplier="0.001" name="outlet.voltage" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.3.%i.1.1" power_status="yes"/>
 		<snmp_info multiplier="0.01" name="outlet.current" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.4.%i.1.1" power_status="yes"/>
@@ -374,6 +374,6 @@
 		<snmp_info command="yes" multiplier="1.0" name="outlet.group.%i.load.on.delay" oid=".1.3.6.1.4.1.534.6.6.7.5.6.1.4.%i.%i" outlet_group="yes" type_daisy="1"/>
 		<snmp_info command="yes" multiplier="1.0" name="outlet.group.%i.load.cycle.delay" oid=".1.3.6.1.4.1.534.6.6.7.5.6.1.5.%i.%i" outlet_group="yes" type_daisy="1"/>
 	</snmp>
-	<mib2nut auto_check=".1.3.6.1.4.1.534.6.6.7.1.2.1.2.0" mib_name="eaton_epdu" name="eaton_marlin" oid=".1.3.6.1.4.1.534.6.6.7" snmp_info="eaton_marlin_mib" version="0.56"/>
+	<mib2nut auto_check=".1.3.6.1.4.1.534.6.6.7.1.2.1.2.0" mib_name="eaton_epdu" name="eaton_marlin" oid=".1.3.6.1.4.1.534.6.6.7" snmp_info="eaton_marlin_mib" version="0.57"/>
 </nut>
 


### PR DESCRIPTION
Fix a regression that caused a mis-determination of the SNMP base
OID index (0 or 1, should be 1). This in turn caused a mis-iteration
over the outlets, from 0 to N-1 instead of 1 to N, which resulted in
the missing Nth outlet (last outlet of the PDU). This also caused some
data refresh issues

Signed-off-by: Arnaud Quette <ArnaudQuette@eaton.com>

Replay of https://github.com/42ity/nut/pull/124 into main development