### PR TITLE
Jenkinsfile: fix detection of "GitIgnores good after make" (shell exit-code, groovy quotes for evaluation)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -137,9 +137,10 @@ pipeline {
         stage ('compile') {
                     steps {
                         sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make -k -j4 all || make all'
-                        sh """ echo "Are GitIgnores good after make? (should have no output below)"
-OUT="`git status -s`" && [ -z "\$OUT" ] \
-|| {echo "\$OUT" >&2
+                        sh """ set +x
+echo "Are GitIgnores good after make? (should have no output below)"
+OUT="`git status -s`" && [ -z "\$OUT" ] \\
+|| { echo "\$OUT" >&2
     if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then
         echo "WARNING GitIgnore tests found newly changed or untracked files:" >&2
         exit 0
@@ -219,9 +220,10 @@ OUT="`git status -s`" && [ -z "\$OUT" ] \
                                 timeout (time: "${params.USE_TEST_TIMEOUT}".toInteger(), unit: 'MINUTES') {
                                     sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make check'
                                 }
-                                sh """ echo "Are GitIgnores good after make check? (should have no output below)"
-OUT="`git status -s`" && [ -z "\$OUT" ] \
-|| {echo "\$OUT" >&2
+                                sh """ set +x
+echo "Are GitIgnores good after make check? (should have no output below)"
+OUT="`git status -s`" && [ -z "\$OUT" ] \\
+|| { echo "\$OUT" >&2
     if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then
         echo "WARNING GitIgnore tests found newly changed or untracked files:" >&2
         exit 0
@@ -241,9 +243,10 @@ OUT="`git status -s`" && [ -z "\$OUT" ] \
                                 timeout (time: "${params.USE_TEST_TIMEOUT}".toInteger(), unit: 'MINUTES') {
                                     sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make check'
                                 }
-                                sh """ echo "Are GitIgnores good after make check? (should have no output below)"
-OUT="`git status -s`" && [ -z "\$OUT" ] \
-|| {echo "\$OUT" >&2
+                                sh """ set +x
+echo "Are GitIgnores good after make check? (should have no output below)"
+OUT="`git status -s`" && [ -z "\$OUT" ] \\
+|| { echo "\$OUT" >&2
     if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then
         echo "WARNING GitIgnore tests found newly changed or untracked files:" >&2
         exit 0
@@ -275,9 +278,10 @@ OUT="`git status -s`" && [ -z "\$OUT" ] \
                                 timeout (time: "${params.USE_TEST_TIMEOUT}".toInteger(), unit: 'MINUTES') {
                                     sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make memcheck && exit 0 ; echo "Re-running failed ($?) memcheck with greater verbosity" >&2 ; make VERBOSE=1 memcheck-verbose'
                                 }
-                                sh """ echo "Are GitIgnores good after make memcheck? (should have no output below)"
-OUT="`git status -s`" && [ -z "\$OUT" ] \
-|| {echo "\$OUT" >&2
+                                sh """ set +x
+echo "Are GitIgnores good after make memcheck? (should have no output below)"
+OUT="`git status -s`" && [ -z "\$OUT" ] \\
+|| { echo "\$OUT" >&2
     if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then
         echo "WARNING GitIgnore tests found newly changed or untracked files:" >&2
         exit 0
@@ -297,9 +301,10 @@ OUT="`git status -s`" && [ -z "\$OUT" ] \
                                 timeout (time: "${params.USE_TEST_TIMEOUT}".toInteger(), unit: 'MINUTES') {
                                     sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make memcheck && exit 0 ; echo "Re-running failed ($?) memcheck with greater verbosity" >&2 ; make VERBOSE=1 memcheck-verbose'
                                 }
-                                sh """ echo "Are GitIgnores good after make memcheck? (should have no output below)"
-OUT="`git status -s`" && [ -z "\$OUT" ] \
-|| {echo "\$OUT" >&2
+                                sh """ set +x
+echo "Are GitIgnores good after make memcheck? (should have no output below)"
+OUT="`git status -s`" && [ -z "\$OUT" ] \\
+|| { echo "\$OUT" >&2
     if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then
         echo "WARNING GitIgnore tests found newly changed or untracked files:" >&2
         exit 0
@@ -331,9 +336,10 @@ OUT="`git status -s`" && [ -z "\$OUT" ] \
                                 timeout (time: "${params.USE_TEST_TIMEOUT}".toInteger(), unit: 'MINUTES') {
                                     sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make DISTCHECK_CONFIGURE_FLAGS="--with-neon=yes --with-lua=yes --with-snmp=yes --with-snmp_dmf_lua=yes --with-dev --with-doc=html-single=auto,man=yes --with-dmfnutscan-regenerate=yes --with-dmfsnmp-regenerate=auto --with-dmfsnmp-validate=yes --with-dmfnutscan-validate=yes" distcheck'
                                 }
-                                sh """ echo "Are GitIgnores good after make distcheck? (should have no output below)"
-OUT="`git status -s`" && [ -z "\$OUT" ] \
-|| {echo "\$OUT" >&2
+                                sh """ set +x
+echo "Are GitIgnores good after make distcheck? (should have no output below)"
+OUT="`git status -s`" && [ -z "\$OUT" ] \\
+|| { echo "\$OUT" >&2
     if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then
         echo "WARNING GitIgnore tests found newly changed or untracked files:" >&2
         exit 0
@@ -353,9 +359,10 @@ OUT="`git status -s`" && [ -z "\$OUT" ] \
                                 timeout (time: "${params.USE_TEST_TIMEOUT}".toInteger(), unit: 'MINUTES') {
                                     sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make DISTCHECK_CONFIGURE_FLAGS="--with-neon=yes --with-lua=yes --with-snmp=yes --with-snmp_dmf_lua=yes --with-dev --with-doc=html-single=auto,man=yes --with-dmfnutscan-regenerate=yes --with-dmfsnmp-regenerate=auto --with-dmfsnmp-validate=yes --with-dmfnutscan-validate=yes" distcheck'
                                 }
-                                sh """ echo "Are GitIgnores good after make distcheck? (should have no output below)"
-OUT="`git status -s`" && [ -z "\$OUT" ] \
-|| {echo "\$OUT" >&2
+                                sh """ set +x
+echo "Are GitIgnores good after make distcheck? (should have no output below)"
+OUT="`git status -s`" && [ -z "\$OUT" ] \\
+|| { echo "\$OUT" >&2
     if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then
         echo "WARNING GitIgnore tests found newly changed or untracked files:" >&2
         exit 0
@@ -387,9 +394,10 @@ OUT="`git status -s`" && [ -z "\$OUT" ] \
                                 timeout (time: "${params.USE_TEST_TIMEOUT}".toInteger(), unit: 'MINUTES') {
                                     sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make distcheck-dmf-all-yes'
                                 }
-                                sh """ echo "Are GitIgnores good after make distcheck-dmf-all-yes? (should have no output below)"
-OUT="`git status -s`" && [ -z "\$OUT" ] \
-|| {echo "\$OUT" >&2
+                                sh """ set +x
+echo "Are GitIgnores good after make distcheck-dmf-all-yes? (should have no output below)"
+OUT="`git status -s`" && [ -z "\$OUT" ] \\
+|| { echo "\$OUT" >&2
     if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then
         echo "WARNING GitIgnore tests found newly changed or untracked files:" >&2
         exit 0
@@ -409,9 +417,10 @@ OUT="`git status -s`" && [ -z "\$OUT" ] \
                                 timeout (time: "${params.USE_TEST_TIMEOUT}".toInteger(), unit: 'MINUTES') {
                                     sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make distcheck-dmf-all-yes'
                                 }
-                                sh """ echo "Are GitIgnores good after make distcheck-dmf-all-yes? (should have no output below)"
-OUT="`git status -s`" && [ -z "\$OUT" ] \
-|| {echo "\$OUT" >&2
+                                sh """ set +x
+echo "Are GitIgnores good after make distcheck-dmf-all-yes? (should have no output below)"
+OUT="`git status -s`" && [ -z "\$OUT" ] \\
+|| { echo "\$OUT" >&2
     if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then
         echo "WARNING GitIgnore tests found newly changed or untracked files:" >&2
         exit 0
@@ -443,9 +452,10 @@ OUT="`git status -s`" && [ -z "\$OUT" ] \
                                 timeout (time: "${params.USE_TEST_TIMEOUT}".toInteger(), unit: 'MINUTES') {
                                     sh """CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make DESTDIR="${params.USE_TEST_INSTALL_DESTDIR}" install"""
                                 }
-                                sh """ echo "Are GitIgnores good after make install? (should have no output below)"
-OUT="`git status -s`" && [ -z "\$OUT" ] \
-|| {echo "\$OUT" >&2
+                                sh """ set +x
+echo "Are GitIgnores good after make install? (should have no output below)"
+OUT="`git status -s`" && [ -z "\$OUT" ] \\
+|| { echo "\$OUT" >&2
     if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then
         echo "WARNING GitIgnore tests found newly changed or untracked files:" >&2
         exit 0
@@ -465,9 +475,10 @@ OUT="`git status -s`" && [ -z "\$OUT" ] \
                                 timeout (time: "${params.USE_TEST_TIMEOUT}".toInteger(), unit: 'MINUTES') {
                                     sh """CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make DESTDIR="${params.USE_TEST_INSTALL_DESTDIR}" install"""
                                 }
-                                sh """ echo "Are GitIgnores good after make install? (should have no output below)"
-OUT="`git status -s`" && [ -z "\$OUT" ] \
-|| {echo "\$OUT" >&2
+                                sh """ set +x
+echo "Are GitIgnores good after make install? (should have no output below)"
+OUT="`git status -s`" && [ -z "\$OUT" ] \\
+|| { echo "\$OUT" >&2
     if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then
         echo "WARNING GitIgnore tests found newly changed or untracked files:" >&2
         exit 0

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -137,7 +137,18 @@ pipeline {
         stage ('compile') {
                     steps {
                         sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make -k -j4 all || make all'
-                        sh 'echo "Are GitIgnores good after make? (should have no output below)"; git status -s || if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then echo "WARNING GitIgnore tests found newly changed or untracked files" >&2 ; exit 0 ; else echo "FAILED GitIgnore tests" >&2 ; git diff; exit 1; fi'
+                        sh """ echo "Are GitIgnores good after make? (should have no output below)"
+OUT="`git status -s`" && [ -z "\$OUT" ] \
+|| {echo "\$OUT" >&2
+    if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then
+        echo "WARNING GitIgnore tests found newly changed or untracked files:" >&2
+        exit 0
+    else
+        echo "FAILED GitIgnore tests" >&2
+        git diff >&2
+        exit 1
+    fi
+}"""
                         script {
                           if ( (params.DO_TEST_CHECK && params.DO_TEST_MEMCHECK) || (params.DO_TEST_CHECK && params.DO_TEST_DISTCHECK) || (params.DO_TEST_MEMCHECK && params.DO_TEST_DISTCHECK) ||
                                (params.DO_TEST_INSTALL && params.DO_TEST_MEMCHECK) || (params.DO_TEST_INSTALL && params.DO_TEST_DISTCHECK) || (params.DO_TEST_INSTALL && params.DO_TEST_CHECK)
@@ -208,7 +219,18 @@ pipeline {
                                 timeout (time: "${params.USE_TEST_TIMEOUT}".toInteger(), unit: 'MINUTES') {
                                     sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make check'
                                 }
-                                sh 'echo "Are GitIgnores good after make check? (should have no output below)"; git status -s || if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then echo "WARNING GitIgnore tests found newly changed or untracked files" >&2 ; exit 0 ; else echo "FAILED GitIgnore tests" >&2 ; git diff; exit 1; fi'
+                                sh """ echo "Are GitIgnores good after make check? (should have no output below)"
+OUT="`git status -s`" && [ -z "\$OUT" ] \
+|| {echo "\$OUT" >&2
+    if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then
+        echo "WARNING GitIgnore tests found newly changed or untracked files:" >&2
+        exit 0
+    else
+        echo "FAILED GitIgnore tests" >&2
+        git diff >&2
+        exit 1
+    fi
+}"""
                                 script {
                                     if ( params.DO_CLEANUP_AFTER_BUILD ) {
                                         deleteDir()
@@ -219,7 +241,18 @@ pipeline {
                                 timeout (time: "${params.USE_TEST_TIMEOUT}".toInteger(), unit: 'MINUTES') {
                                     sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make check'
                                 }
-                                sh 'echo "Are GitIgnores good after make check? (should have no output below)"; git status -s || if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then echo "WARNING GitIgnore tests found newly changed or untracked files" >&2 ; exit 0 ; else echo "FAILED GitIgnore tests" >&2 ; git diff; exit 1; fi'
+                                sh """ echo "Are GitIgnores good after make check? (should have no output below)"
+OUT="`git status -s`" && [ -z "\$OUT" ] \
+|| {echo "\$OUT" >&2
+    if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then
+        echo "WARNING GitIgnore tests found newly changed or untracked files:" >&2
+        exit 0
+    else
+        echo "FAILED GitIgnore tests" >&2
+        git diff >&2
+        exit 1
+    fi
+}"""
                           }
                         }
                     }
@@ -242,7 +275,18 @@ pipeline {
                                 timeout (time: "${params.USE_TEST_TIMEOUT}".toInteger(), unit: 'MINUTES') {
                                     sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make memcheck && exit 0 ; echo "Re-running failed ($?) memcheck with greater verbosity" >&2 ; make VERBOSE=1 memcheck-verbose'
                                 }
-                                sh 'echo "Are GitIgnores good after make memcheck? (should have no output below)"; git status -s || if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then echo "WARNING GitIgnore tests found newly changed or untracked files" >&2 ; exit 0 ; else echo "FAILED GitIgnore tests" >&2 ; git diff; exit 1; fi'
+                                sh """ echo "Are GitIgnores good after make memcheck? (should have no output below)"
+OUT="`git status -s`" && [ -z "\$OUT" ] \
+|| {echo "\$OUT" >&2
+    if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then
+        echo "WARNING GitIgnore tests found newly changed or untracked files:" >&2
+        exit 0
+    else
+        echo "FAILED GitIgnore tests" >&2
+        git diff >&2
+        exit 1
+    fi
+}"""
                                 script {
                                     if ( params.DO_CLEANUP_AFTER_BUILD ) {
                                         deleteDir()
@@ -253,7 +297,18 @@ pipeline {
                                 timeout (time: "${params.USE_TEST_TIMEOUT}".toInteger(), unit: 'MINUTES') {
                                     sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make memcheck && exit 0 ; echo "Re-running failed ($?) memcheck with greater verbosity" >&2 ; make VERBOSE=1 memcheck-verbose'
                                 }
-                                sh 'echo "Are GitIgnores good after make memcheck? (should have no output below)"; git status -s || if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then echo "WARNING GitIgnore tests found newly changed or untracked files" >&2 ; exit 0 ; else echo "FAILED GitIgnore tests" >&2 ; git diff; exit 1; fi'
+                                sh """ echo "Are GitIgnores good after make memcheck? (should have no output below)"
+OUT="`git status -s`" && [ -z "\$OUT" ] \
+|| {echo "\$OUT" >&2
+    if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then
+        echo "WARNING GitIgnore tests found newly changed or untracked files:" >&2
+        exit 0
+    else
+        echo "FAILED GitIgnore tests" >&2
+        git diff >&2
+        exit 1
+    fi
+}"""
                           }
                       }
                     }
@@ -276,7 +331,18 @@ pipeline {
                                 timeout (time: "${params.USE_TEST_TIMEOUT}".toInteger(), unit: 'MINUTES') {
                                     sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make DISTCHECK_CONFIGURE_FLAGS="--with-neon=yes --with-lua=yes --with-snmp=yes --with-snmp_dmf_lua=yes --with-dev --with-doc=html-single=auto,man=yes --with-dmfnutscan-regenerate=yes --with-dmfsnmp-regenerate=auto --with-dmfsnmp-validate=yes --with-dmfnutscan-validate=yes" distcheck'
                                 }
-                                sh 'echo "Are GitIgnores good after make distcheck? (should have no output below)"; git status -s || if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then echo "WARNING GitIgnore tests found newly changed or untracked files" >&2 ; exit 0 ; else echo "FAILED GitIgnore tests" >&2 ; git diff; exit 1; fi'
+                                sh """ echo "Are GitIgnores good after make distcheck? (should have no output below)"
+OUT="`git status -s`" && [ -z "\$OUT" ] \
+|| {echo "\$OUT" >&2
+    if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then
+        echo "WARNING GitIgnore tests found newly changed or untracked files:" >&2
+        exit 0
+    else
+        echo "FAILED GitIgnore tests" >&2
+        git diff >&2
+        exit 1
+    fi
+}"""
                                 script {
                                     if ( params.DO_CLEANUP_AFTER_BUILD ) {
                                         deleteDir()
@@ -287,7 +353,18 @@ pipeline {
                                 timeout (time: "${params.USE_TEST_TIMEOUT}".toInteger(), unit: 'MINUTES') {
                                     sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make DISTCHECK_CONFIGURE_FLAGS="--with-neon=yes --with-lua=yes --with-snmp=yes --with-snmp_dmf_lua=yes --with-dev --with-doc=html-single=auto,man=yes --with-dmfnutscan-regenerate=yes --with-dmfsnmp-regenerate=auto --with-dmfsnmp-validate=yes --with-dmfnutscan-validate=yes" distcheck'
                                 }
-                                sh 'echo "Are GitIgnores good after make distcheck? (should have no output below)"; git status -s || if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then echo "WARNING GitIgnore tests found newly changed or untracked files" >&2 ; exit 0 ; else echo "FAILED GitIgnore tests" >&2 ; git diff; exit 1; fi'
+                                sh """ echo "Are GitIgnores good after make distcheck? (should have no output below)"
+OUT="`git status -s`" && [ -z "\$OUT" ] \
+|| {echo "\$OUT" >&2
+    if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then
+        echo "WARNING GitIgnore tests found newly changed or untracked files:" >&2
+        exit 0
+    else
+        echo "FAILED GitIgnore tests" >&2
+        git diff >&2
+        exit 1
+    fi
+}"""
                             }
                         }
                     }
@@ -310,7 +387,18 @@ pipeline {
                                 timeout (time: "${params.USE_TEST_TIMEOUT}".toInteger(), unit: 'MINUTES') {
                                     sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make distcheck-dmf-all-yes'
                                 }
-                                sh 'echo "Are GitIgnores good after make distcheck-dmf-all-yes? (should have no output below)"; git status -s || if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then echo "WARNING GitIgnore tests found newly changed or untracked files" >&2 ; exit 0 ; else echo "FAILED GitIgnore tests" >&2 ; git diff; exit 1; fi'
+                                sh """ echo "Are GitIgnores good after make distcheck-dmf-all-yes? (should have no output below)"
+OUT="`git status -s`" && [ -z "\$OUT" ] \
+|| {echo "\$OUT" >&2
+    if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then
+        echo "WARNING GitIgnore tests found newly changed or untracked files:" >&2
+        exit 0
+    else
+        echo "FAILED GitIgnore tests" >&2
+        git diff >&2
+        exit 1
+    fi
+}"""
                                 script {
                                     if ( params.DO_CLEANUP_AFTER_BUILD ) {
                                         deleteDir()
@@ -321,7 +409,18 @@ pipeline {
                                 timeout (time: "${params.USE_TEST_TIMEOUT}".toInteger(), unit: 'MINUTES') {
                                     sh 'CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make distcheck-dmf-all-yes'
                                 }
-                                sh 'echo "Are GitIgnores good after make distcheck-dmf-all-yes? (should have no output below)"; git status -s || if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then echo "WARNING GitIgnore tests found newly changed or untracked files" >&2 ; exit 0 ; else echo "FAILED GitIgnore tests" >&2 ; git diff; exit 1; fi'
+                                sh """ echo "Are GitIgnores good after make distcheck-dmf-all-yes? (should have no output below)"
+OUT="`git status -s`" && [ -z "\$OUT" ] \
+|| {echo "\$OUT" >&2
+    if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then
+        echo "WARNING GitIgnore tests found newly changed or untracked files:" >&2
+        exit 0
+    else
+        echo "FAILED GitIgnore tests" >&2
+        git diff >&2
+        exit 1
+    fi
+}"""
                             }
                         }
                     }
@@ -344,7 +443,18 @@ pipeline {
                                 timeout (time: "${params.USE_TEST_TIMEOUT}".toInteger(), unit: 'MINUTES') {
                                     sh """CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make DESTDIR="${params.USE_TEST_INSTALL_DESTDIR}" install"""
                                 }
-                                sh 'echo "Are GitIgnores good after make install? (should have no output below)"; git status -s || if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then echo "WARNING GitIgnore tests found newly changed or untracked files" >&2 ; exit 0 ; else echo "FAILED GitIgnore tests" >&2 ; git diff; exit 1; fi'
+                                sh """ echo "Are GitIgnores good after make install? (should have no output below)"
+OUT="`git status -s`" && [ -z "\$OUT" ] \
+|| {echo "\$OUT" >&2
+    if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then
+        echo "WARNING GitIgnore tests found newly changed or untracked files:" >&2
+        exit 0
+    else
+        echo "FAILED GitIgnore tests" >&2
+        git diff >&2
+        exit 1
+    fi
+}"""
                                 script {
                                     if ( params.DO_CLEANUP_AFTER_BUILD ) {
                                         deleteDir()
@@ -355,7 +465,18 @@ pipeline {
                                 timeout (time: "${params.USE_TEST_TIMEOUT}".toInteger(), unit: 'MINUTES') {
                                     sh """CCACHE_BASEDIR="`pwd`" ; export CCACHE_BASEDIR; make DESTDIR="${params.USE_TEST_INSTALL_DESTDIR}" install"""
                                 }
-                                sh 'echo "Are GitIgnores good after make install? (should have no output below)"; git status -s || if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then echo "WARNING GitIgnore tests found newly changed or untracked files" >&2 ; exit 0 ; else echo "FAILED GitIgnore tests" >&2 ; git diff; exit 1; fi'
+                                sh """ echo "Are GitIgnores good after make install? (should have no output below)"
+OUT="`git status -s`" && [ -z "\$OUT" ] \
+|| {echo "\$OUT" >&2
+    if [ "${params.CI_REQUIRE_GOOD_GITIGNORE}" = false ]; then
+        echo "WARNING GitIgnore tests found newly changed or untracked files:" >&2
+        exit 0
+    else
+        echo "FAILED GitIgnore tests" >&2
+        git diff >&2
+        exit 1
+    fi
+}"""
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -490,7 +490,7 @@ OUT="`git status -s`" && [ -z "\$OUT" ] \
                     branch 'master'
                     branch "release/*"
                     changeRequest()
-                }    
+                }
             }
             stages {
                 stage('Compile') {

--- a/docs/config-prereqs.txt
+++ b/docs/config-prereqs.txt
@@ -13,7 +13,8 @@ both, at a disk space cost.
 
 NOTE: Some NUT branches may need additional or different software versions
 that are not yet included into `master` branch dependencies, e.g. the DMF
-(Dynamic Mapping Files) sub-project needs LUA 5.1.
+(Dynamic Mapping Files) sub-project needs LUA 5.1 for build and run-time,
+and some Python modules for build.
 
 More packages and/or system setup may be needed to actually run NUT with
 all features enabled; chapters below concern just with building it.
@@ -107,6 +108,9 @@ complete environments):
 NOTE: For Jenkins agents, also need to `apt-get install openjdk-11-jdk-headless`
 (technically, needs at least JRE 8+).
 
+For DMF, additionally install `python-pycparser` (or in newer distributions,
+an explicitly versioned package, e.g. `python3-pycparser`).
+
 FreeBSD 12.2
 ~~~~~~~~~~~~
 
@@ -171,6 +175,8 @@ scripts), better use this routine to test the config/build:
 
 Note the lack of `pkg-config` also precludes libcppunit tests, although they
 also tend to mis-compile/mis-link with GCC (while CLANG seems okay).
+
+DMF builds were not tested on BSD as of yet.
 
 OpenIndiana 2021.04
 ~~~~~~~~~~~~~~~~~~~
@@ -247,6 +253,10 @@ from third-party repositories (e.g. SFE) and/or build from sources.
 
 NOTE: For Jenkins agents, also need to `pkg install developer/java/openjdk8`
 (or 11+).
+
+For DMF, additionally install `library/python/pycparser` (or a versioned one
+matching your installed Python distribution, e.g. `library/python/pycparser-39`
+or `library/python/pycparser-27`).
 
 OmniOS CE (as of release 151036)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/nut.dict
+++ b/docs/nut.dict
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 2808 utf-8
+personal_ws-1.1 en 2809 utf-8
 AAS
 ACFAIL
 ACFREQ
@@ -1457,10 +1457,12 @@ byv
 cablepower
 calloc
 cb
+cbe
 cbl
 cblimit
 ccache
 cd
+cef
 cerr
 certfile
 certname
@@ -1999,10 +2001,9 @@ lowvoltsout
 lposix
 lr
 lsusb
-lua
-luaOutlet
 lu
 lua
+luaOutlet
 lv
 lvo
 lxc

--- a/scripts/DMF/Makefile.am
+++ b/scripts/DMF/Makefile.am
@@ -209,6 +209,7 @@ if WITH_REGENERATE_DMF_SNMP
 	test -d "$(@D)" -a -w "$(@D)" || $(MKDIR_P) "$(@D)" || exit ; \
 	if test -f "$(DMFGEN_SANITY_VALIDATED)" ; then \
 	    ( cd "$(@D)" && \
+	      LANG=C LC_ALL=C TZ=UTC \
 	      CFLAGS="$(DMFTOOLS_CFLAGS) $(AM_CFLAGS)" \
 	      LDFLAGSx="$(abs_top_builddir)/common/libcommon.la $(abs_top_builddir)/drivers/dstate.o" \
 	      CPPFLAGS="$(DMFTOOLS_CPPFLAGS) $(CPPFLAGS) $(AM_CPPFLAGS)" \

--- a/scripts/DMF/dmfify-mib.sh
+++ b/scripts/DMF/dmfify-mib.sh
@@ -47,7 +47,7 @@ fi
 || { echo "ERROR: Can not find Python 2.7+: '$PYTHON'" >&2; exit 2; }
 
 # The pycparser uses GCC-compatible flags
-[ -n "${CC-}" ] || CC="`which gcc`"
+[ -n "${CC-}" ] || CC="`command -v gcc`"
 CC_ENV=""
 if [ -n "${CC-}" ] ; then
     case "$CC" in
@@ -72,13 +72,13 @@ if [ -n "${CC-}" ] ; then
     esac
     case "$CC" in
         /*) ;;
-        *)  CC="`which "$CC"`" ;;
+        *)  CC="`command -v "$CC"`" ;;
     esac
 fi
 [ -n "${CC}" ] && [ -x "$CC" ] || { echo "ERROR: Can not find (G)CC: '$CC'" >&2; exit 2; }
 export CC CFLAGS CC_ENV
 
-[ -n "${CPP-}" ] || CPP="`which cpp`"
+[ -n "${CPP-}" ] || CPP="`command -v cpp`"
 CPP_ENV=""
 if [ -n "${CPP-}" ] ; then
     case "$CPP" in
@@ -103,7 +103,7 @@ if [ -n "${CPP-}" ] ; then
     esac
     case "$CPP" in
         /*) ;;
-        *)  CPP="`which "$CPP"`" ;;
+        *)  CPP="`command -v "$CPP"`" ;;
     esac
 fi
 [ -n "${CPP}" ] && [ -x "$CPP" ] || { echo "ERROR: Can not find a C preprocessor: '$CPP'" >&2; exit 2; }

--- a/scripts/DMF/dmfsnmp/apc-ats-mib.dmf
+++ b/scripts/DMF/dmfsnmp/apc-ats-mib.dmf
@@ -1,9 +1,5 @@
 <?xml version="1.0" ?>
 <nut version="1.0.0" xmlns="http://www.networkupstools.org/dmf/snmp/snmp-ups">
-	<lookup name="apc_ats_sensitivity_info">
-		<lookup_info oid="1" value="high"/>
-		<lookup_info oid="2" value="low"/>
-	</lookup>
 	<lookup name="apc_ats_outletgroups_name_info">
 		<lookup_info oid="1" value="total"/>
 		<lookup_info oid="2" value="bank1"/>
@@ -18,6 +14,10 @@
 	<lookup name="apc_ats_output_status_info">
 		<lookup_info oid="1" value="OFF"/>
 		<lookup_info oid="2" value="OL"/>
+	</lookup>
+	<lookup name="apc_ats_sensitivity_info">
+		<lookup_info oid="1" value="high"/>
+		<lookup_info oid="2" value="low"/>
 	</lookup>
 	<snmp name="apc_ats_mib">
 		<snmp_info absent="yes" default="ats" flag_ok="yes" multiplier="128.0" name="device.type" static="yes" string="yes"/>

--- a/scripts/DMF/dmfsnmp/apc-mib.dmf
+++ b/scripts/DMF/dmfsnmp/apc-mib.dmf
@@ -1,37 +1,13 @@
 <?xml version="1.0" ?>
 <nut version="1.0.0" xmlns="http://www.networkupstools.org/dmf/snmp/snmp-ups">
-	<lookup name="apcc_transfer_reasons">
-		<lookup_info oid="1" value="noTransfer"/>
-		<lookup_info oid="2" value="highLineVoltage"/>
-		<lookup_info oid="3" value="brownout"/>
-		<lookup_info oid="4" value="blackout"/>
-		<lookup_info oid="5" value="smallMomentarySag"/>
-		<lookup_info oid="6" value="deepMomentarySag"/>
-		<lookup_info oid="7" value="smallMomentarySpike"/>
-		<lookup_info oid="8" value="largeMomentarySpike"/>
-		<lookup_info oid="9" value="selfTest"/>
-		<lookup_info oid="10" value="rateOfVoltageChange"/>
-	</lookup>
-	<lookup name="apcc_battrepl_info">
-		<lookup_info oid="1" value=""/>
-		<lookup_info oid="2" value="RB"/>
-	</lookup>
-	<lookup name="apcc_testdiag_results">
-		<lookup_info oid="1" value="Ok"/>
-		<lookup_info oid="2" value="Failed"/>
-		<lookup_info oid="3" value="InvalidTest"/>
-		<lookup_info oid="4" value="TestInProgress"/>
-	</lookup>
-	<lookup name="apcc_sensitivity_modes">
-		<lookup_info oid="1" value="auto"/>
-		<lookup_info oid="2" value="low"/>
-		<lookup_info oid="3" value="medium"/>
-		<lookup_info oid="4" value="high"/>
-	</lookup>
 	<lookup name="apcc_batt_info">
 		<lookup_info oid="1" value=""/>
 		<lookup_info oid="2" value=""/>
 		<lookup_info oid="3" value="LB"/>
+	</lookup>
+	<lookup name="apcc_battrepl_info">
+		<lookup_info oid="1" value=""/>
+		<lookup_info oid="2" value="RB"/>
 	</lookup>
 	<lookup name="apcc_cal_info">
 		<lookup_info oid="1" value=""/>
@@ -51,6 +27,30 @@
 		<lookup_info oid="10" value="BYPASS"/>
 		<lookup_info oid="11" value="OFF"/>
 		<lookup_info oid="12" value="OL TRIM"/>
+	</lookup>
+	<lookup name="apcc_sensitivity_modes">
+		<lookup_info oid="1" value="auto"/>
+		<lookup_info oid="2" value="low"/>
+		<lookup_info oid="3" value="medium"/>
+		<lookup_info oid="4" value="high"/>
+	</lookup>
+	<lookup name="apcc_testdiag_results">
+		<lookup_info oid="1" value="Ok"/>
+		<lookup_info oid="2" value="Failed"/>
+		<lookup_info oid="3" value="InvalidTest"/>
+		<lookup_info oid="4" value="TestInProgress"/>
+	</lookup>
+	<lookup name="apcc_transfer_reasons">
+		<lookup_info oid="1" value="noTransfer"/>
+		<lookup_info oid="2" value="highLineVoltage"/>
+		<lookup_info oid="3" value="brownout"/>
+		<lookup_info oid="4" value="blackout"/>
+		<lookup_info oid="5" value="smallMomentarySag"/>
+		<lookup_info oid="6" value="deepMomentarySag"/>
+		<lookup_info oid="7" value="smallMomentarySpike"/>
+		<lookup_info oid="8" value="largeMomentarySpike"/>
+		<lookup_info oid="9" value="selfTest"/>
+		<lookup_info oid="10" value="rateOfVoltageChange"/>
 	</lookup>
 	<snmp name="apcc_mib">
 		<snmp_info absent="yes" default="APC" flag_ok="yes" multiplier="128.0" name="ups.mfr" static="yes" string="yes"/>

--- a/scripts/DMF/dmfsnmp/compaq-mib.dmf
+++ b/scripts/DMF/dmfsnmp/compaq-mib.dmf
@@ -1,17 +1,8 @@
 <?xml version="1.0" ?>
 <nut version="1.0.0" xmlns="http://www.networkupstools.org/dmf/snmp/snmp-ups">
-	<lookup name="cpqpower_outlet_switchability_info">
-		<lookup_info oid="1" value="yes"/>
-		<lookup_info oid="2" value="yes"/>
-		<lookup_info oid="3" value="yes"/>
-		<lookup_info oid="4" value="yes"/>
-	</lookup>
-	<lookup name="cpqpower_outlet_status_info">
-		<lookup_info oid="1" value="on"/>
-		<lookup_info oid="2" value="off"/>
-		<lookup_info oid="3" value="pendingOff"/>
-		<lookup_info oid="4" value="pendingOn"/>
-		<lookup_info oid="5" value="unknown"/>
+	<lookup name="cpqpower_battery_abm_status">
+		<lookup_info oid="1" value="CHRG"/>
+		<lookup_info oid="2" value="DISCHRG"/>
 	</lookup>
 	<lookup name="cpqpower_mode_info">
 		<lookup_info oid="1" value=""/>
@@ -24,6 +15,19 @@
 		<lookup_info oid="8" value="parallel capacity"/>
 		<lookup_info oid="9" value="parallel redundancy"/>
 		<lookup_info oid="10" value="high efficiency"/>
+	</lookup>
+	<lookup name="cpqpower_outlet_status_info">
+		<lookup_info oid="1" value="on"/>
+		<lookup_info oid="2" value="off"/>
+		<lookup_info oid="3" value="pendingOff"/>
+		<lookup_info oid="4" value="pendingOn"/>
+		<lookup_info oid="5" value="unknown"/>
+	</lookup>
+	<lookup name="cpqpower_outlet_switchability_info">
+		<lookup_info oid="1" value="yes"/>
+		<lookup_info oid="2" value="yes"/>
+		<lookup_info oid="3" value="yes"/>
+		<lookup_info oid="4" value="yes"/>
 	</lookup>
 	<lookup name="cpqpower_pwr_info">
 		<lookup_info oid="1" value=""/>
@@ -45,10 +49,6 @@
 		<lookup_info oid="5" value="Not supported"/>
 		<lookup_info oid="6" value="Inhibited"/>
 		<lookup_info oid="7" value="Scheduled"/>
-	</lookup>
-	<lookup name="cpqpower_battery_abm_status">
-		<lookup_info oid="1" value="CHRG"/>
-		<lookup_info oid="2" value="DISCHRG"/>
 	</lookup>
 	<snmp name="cpqpower_mib">
 		<snmp_info default="HP/Compaq" multiplier="128.0" name="ups.mfr" oid=".1.3.6.1.4.1.232.165.3.1.1.0" static="yes" string="yes"/>

--- a/scripts/DMF/dmfsnmp/cyberpower-mib.dmf
+++ b/scripts/DMF/dmfsnmp/cyberpower-mib.dmf
@@ -5,6 +5,10 @@
 		<lookup_info oid="2" value=""/>
 		<lookup_info oid="3" value="LB"/>
 	</lookup>
+	<lookup name="cyberpower_battrepl_status">
+		<lookup_info oid="1" value=""/>
+		<lookup_info oid="2" value="RB"/>
+	</lookup>
 	<lookup name="cyberpower_cal_status">
 		<lookup_info oid="1" value=""/>
 		<lookup_info oid="2" value=""/>
@@ -18,10 +22,6 @@
 		<lookup_info oid="7" value="OL"/>
 		<lookup_info oid="1" value="NULL"/>
 		<lookup_info oid="6" value="OFF"/>
-	</lookup>
-	<lookup name="cyberpower_battrepl_status">
-		<lookup_info oid="1" value=""/>
-		<lookup_info oid="2" value="RB"/>
 	</lookup>
 	<snmp name="cyberpower_mib">
 		<snmp_info absent="yes" default="ups" flag_ok="yes" multiplier="128.0" name="device.type" static="yes" string="yes"/>

--- a/scripts/DMF/dmfsnmp/eaton-ats16-nm2-mib.dmf
+++ b/scripts/DMF/dmfsnmp/eaton-ats16-nm2-mib.dmf
@@ -4,17 +4,15 @@
 		<lookup_info oid="1" value="good"/>
 		<lookup_info oid="2" value="out-of-range"/>
 	</lookup>
+	<lookup name="eaton_ats16_nm2_input_voltage_status_info">
+		<lookup_info oid="1" value="good"/>
+		<lookup_info oid="2" value="derated-range"/>
+		<lookup_info oid="3" value="out-of-range"/>
+		<lookup_info oid="4" value="unknown"/>
+	</lookup>
 	<lookup name="eaton_ats16_nm2_output_status_info">
 		<lookup_info oid="1" value="OFF"/>
 		<lookup_info oid="2" value="OL"/>
-	</lookup>
-	<lookup name="eaton_ats16_nm2_test_result_info">
-		<lookup_info oid="1" value="done and passed"/>
-		<lookup_info oid="2" value="done and warning"/>
-		<lookup_info oid="3" value="done and error"/>
-		<lookup_info oid="4" value="aborted"/>
-		<lookup_info oid="5" value="in progress"/>
-		<lookup_info oid="6" value="no test initiated"/>
 	</lookup>
 	<lookup name="eaton_ats16_nm2_sensitivity_info">
 		<lookup_info oid="1" value="normal"/>
@@ -30,11 +28,13 @@
 		<lookup_info oid="6" value="safe"/>
 		<lookup_info oid="7" value="fault"/>
 	</lookup>
-	<lookup name="eaton_ats16_nm2_input_voltage_status_info">
-		<lookup_info oid="1" value="good"/>
-		<lookup_info oid="2" value="derated-range"/>
-		<lookup_info oid="3" value="out-of-range"/>
-		<lookup_info oid="4" value="unknown"/>
+	<lookup name="eaton_ats16_nm2_test_result_info">
+		<lookup_info oid="1" value="done and passed"/>
+		<lookup_info oid="2" value="done and warning"/>
+		<lookup_info oid="3" value="done and error"/>
+		<lookup_info oid="4" value="aborted"/>
+		<lookup_info oid="5" value="in progress"/>
+		<lookup_info oid="6" value="no test initiated"/>
 	</lookup>
 	<snmp name="eaton_ats16_nm2_mib">
 		<snmp_info absent="yes" default="ats" flag_ok="yes" multiplier="128.0" name="device.type" static="yes" string="yes"/>

--- a/scripts/DMF/dmfsnmp/eaton-ats16-nmc-mib.dmf
+++ b/scripts/DMF/dmfsnmp/eaton-ats16-nmc-mib.dmf
@@ -1,5 +1,12 @@
 <?xml version="1.0" ?>
 <nut version="1.0.0" xmlns="http://www.networkupstools.org/dmf/snmp/snmp-ups">
+	<lookup name="eaton_ats16_nmc_ambient_drycontacts_info">
+		<lookup_info oid="-1" value="unknown"/>
+		<lookup_info oid="1" value="opened"/>
+		<lookup_info oid="2" value="closed"/>
+		<lookup_info oid="3" value="opened"/>
+		<lookup_info oid="4" value="closed"/>
+	</lookup>
 	<lookup name="eaton_ats16_nmc_input_frequency_status_info">
 		<lookup_info oid="1" value="good"/>
 		<lookup_info oid="2" value="out-of-range"/>
@@ -19,21 +26,6 @@
 		<lookup_info oid="2" value="high"/>
 		<lookup_info oid="3" value="low"/>
 	</lookup>
-	<lookup name="eaton_ats16_nmc_test_result_info">
-		<lookup_info oid="1" value="done and passed"/>
-		<lookup_info oid="2" value="done and warning"/>
-		<lookup_info oid="3" value="done and error"/>
-		<lookup_info oid="4" value="aborted"/>
-		<lookup_info oid="5" value="in progress"/>
-		<lookup_info oid="6" value="no test initiated"/>
-	</lookup>
-	<lookup name="eaton_ats16_nmc_ambient_drycontacts_info">
-		<lookup_info oid="-1" value="unknown"/>
-		<lookup_info oid="1" value="opened"/>
-		<lookup_info oid="2" value="closed"/>
-		<lookup_info oid="3" value="opened"/>
-		<lookup_info oid="4" value="closed"/>
-	</lookup>
 	<lookup name="eaton_ats16_nmc_source_info">
 		<lookup_info oid="1" value="init"/>
 		<lookup_info oid="2" value="diagnosis"/>
@@ -42,6 +34,14 @@
 		<lookup_info oid="5" value="2"/>
 		<lookup_info oid="6" value="safe"/>
 		<lookup_info oid="7" value="fault"/>
+	</lookup>
+	<lookup name="eaton_ats16_nmc_test_result_info">
+		<lookup_info oid="1" value="done and passed"/>
+		<lookup_info oid="2" value="done and warning"/>
+		<lookup_info oid="3" value="done and error"/>
+		<lookup_info oid="4" value="aborted"/>
+		<lookup_info oid="5" value="in progress"/>
+		<lookup_info oid="6" value="no test initiated"/>
 	</lookup>
 	<snmp name="eaton_ats16_nmc_mib">
 		<snmp_info absent="yes" default="ats" flag_ok="yes" multiplier="128.0" name="device.type" static="yes" string="yes"/>

--- a/scripts/DMF/dmfsnmp/eaton-ats30-mib.dmf
+++ b/scripts/DMF/dmfsnmp/eaton-ats30-mib.dmf
@@ -1,5 +1,18 @@
 <?xml version="1.0" ?>
 <nut version="1.0.0" xmlns="http://www.networkupstools.org/dmf/snmp/snmp-ups">
+	<lookup name="eaton_ats30_input_sensitivity">
+		<lookup_info oid="1" value="high"/>
+		<lookup_info oid="2" value="low"/>
+	</lookup>
+	<lookup name="eaton_ats30_source_info">
+		<lookup_info oid="1" value="init"/>
+		<lookup_info oid="2" value="diagnosis"/>
+		<lookup_info oid="3" value="off"/>
+		<lookup_info oid="4" value="1"/>
+		<lookup_info oid="5" value="2"/>
+		<lookup_info oid="6" value="safe"/>
+		<lookup_info oid="7" value="fault"/>
+	</lookup>
 	<lookup name="eaton_ats30_status_info">
 		<lookup_info oid="0" value="OL"/>
 		<lookup_info oid="1" value="OL"/>
@@ -17,19 +30,6 @@
 		<lookup_info oid="13" value="OL OVER"/>
 		<lookup_info oid="14" value="OFF OVER"/>
 		<lookup_info oid="15" value="OFF OVER"/>
-	</lookup>
-	<lookup name="eaton_ats30_input_sensitivity">
-		<lookup_info oid="1" value="high"/>
-		<lookup_info oid="2" value="low"/>
-	</lookup>
-	<lookup name="eaton_ats30_source_info">
-		<lookup_info oid="1" value="init"/>
-		<lookup_info oid="2" value="diagnosis"/>
-		<lookup_info oid="3" value="off"/>
-		<lookup_info oid="4" value="1"/>
-		<lookup_info oid="5" value="2"/>
-		<lookup_info oid="6" value="safe"/>
-		<lookup_info oid="7" value="fault"/>
 	</lookup>
 	<snmp name="eaton_ats30_mib">
 		<snmp_info absent="yes" default="ats" flag_ok="yes" multiplier="128.0" name="device.type" static="yes" string="yes"/>

--- a/scripts/DMF/dmfsnmp/eaton-pdu-marlin-mib.dmf
+++ b/scripts/DMF/dmfsnmp/eaton-pdu-marlin-mib.dmf
@@ -1,9 +1,70 @@
 <?xml version="1.0" ?>
 <nut version="1.0.0" xmlns="http://www.networkupstools.org/dmf/snmp/snmp-ups">
+	<lookup name="eaton_sensor_temperature_unit_info">
+		<lookup_info oid="0" value="kelvin"/>
+		<lookup_info oid="1" value="celsius"/>
+		<lookup_info oid="2" value="fahrenheit"/>
+	</lookup>
+	<lookup name="g2_unit_outlet_switchability_info">
+		<lookup_info oid="-1" value="yes"/>
+		<lookup_info oid="0" value="yes"/>
+	</lookup>
 	<lookup name="marlin_ambient_drycontacts_info">
 		<lookup_info oid="-1" value="unknown"/>
 		<lookup_info oid="0" value="open"/>
 		<lookup_info oid="1" value="closed"/>
+	</lookup>
+	<lookup name="marlin_ambient_drycontacts_polarity_info">
+		<lookup_info oid="0" value="normal-opened"/>
+		<lookup_info oid="1" value="normal-closed"/>
+	</lookup>
+	<lookup name="marlin_ambient_drycontacts_state_info">
+		<lookup_info oid="0" value="inactive"/>
+		<lookup_info oid="1" value="active"/>
+	</lookup>
+	<lookup name="marlin_ambient_presence_info">
+		<lookup_info oid="-1" value="unknown"/>
+		<lookup_info oid="0" value="no"/>
+		<lookup_info oid="1" value="yes"/>
+	</lookup>
+	<lookup name="marlin_emp002_ambient_presence_info">
+		<lookup_info oid="0" value="unknown"/>
+		<lookup_info oid="2" value="yes"/>
+		<lookup_info oid="3" value="no"/>
+	</lookup>
+	<lookup name="marlin_input_type_info">
+		<lookup_info oid="1" value="1"/>
+		<lookup_info oid="2" value="2"/>
+		<lookup_info oid="3" value="3"/>
+		<lookup_info oid="4" value="3"/>
+	</lookup>
+	<lookup name="marlin_outlet_group_phase_info">
+		<lookup_info oid="0" value="unknown"/>
+		<lookup_info oid="1" value="1"/>
+		<lookup_info oid="2" value="1-N"/>
+		<lookup_info oid="3" value="2-N"/>
+		<lookup_info oid="4" value="3-N"/>
+		<lookup_info oid="5" value="1-2"/>
+		<lookup_info oid="6" value="2-3"/>
+		<lookup_info oid="7" value="3-1"/>
+	</lookup>
+	<lookup name="marlin_outlet_group_type_info">
+		<lookup_info oid="0" value="unknown"/>
+		<lookup_info oid="1" value="breaker1pole"/>
+		<lookup_info oid="2" value="breaker2pole"/>
+		<lookup_info oid="3" value="breaker3pole"/>
+		<lookup_info oid="4" value="outlet-section"/>
+		<lookup_info oid="5" value="user-defined"/>
+	</lookup>
+	<lookup name="marlin_outlet_status_info">
+		<lookup_info oid="0" value="off"/>
+		<lookup_info oid="1" value="on"/>
+		<lookup_info oid="2" value="pendingOff"/>
+		<lookup_info oid="3" value="pendingOn"/>
+	</lookup>
+	<lookup name="marlin_outlet_switchability_info">
+		<lookup_info oid="1" value="yes"/>
+		<lookup_info oid="2" value="no"/>
 	</lookup>
 	<lookup name="marlin_outlet_type_info">
 		<lookup_info oid="0" value="unknown"/>
@@ -24,6 +85,12 @@
 		<lookup_info oid="29" value="nemaL715"/>
 		<lookup_info oid="30" value="rf203p277"/>
 	</lookup>
+	<lookup name="marlin_outletgroups_status_info">
+		<lookup_info oid="0" value="off"/>
+		<lookup_info oid="1" value="on"/>
+		<lookup_info oid="2" value="rebooting"/>
+		<lookup_info oid="3" value="mixed"/>
+	</lookup>
 	<lookup name="marlin_threshold_current_alarms_info">
 		<lookup_info oid="0" value=""/>
 		<lookup_info oid="1" value="low current warning!"/>
@@ -31,102 +98,13 @@
 		<lookup_info oid="3" value="high current warning!"/>
 		<lookup_info oid="4" value="high current critical!"/>
 	</lookup>
-	<lookup name="marlin_outletgroups_status_info">
-		<lookup_info oid="0" value="off"/>
-		<lookup_info oid="1" value="on"/>
-		<lookup_info oid="2" value="rebooting"/>
-		<lookup_info oid="3" value="mixed"/>
-	</lookup>
-	<lookup name="marlin_ambient_drycontacts_polarity_info">
-		<lookup_info oid="0" value="normal-opened"/>
-		<lookup_info oid="1" value="normal-closed"/>
-	</lookup>
-	<lookup name="marlin_unit_switchability_info">
-		<lookup_info oid="0" value="no"/>
-		<lookup_info oid="1" value="yes"/>
-		<lookup_info oid="2" value="no"/>
-		<lookup_info oid="3" value="yes"/>
-		<lookup_info oid="4" value="no"/>
-	</lookup>
-	<lookup name="marlin_threshold_temperature_alarms_info">
-		<lookup_info oid="0" value=""/>
-		<lookup_info oid="1" value="low temperature warning!"/>
-		<lookup_info oid="2" value="low temperature critical!"/>
-		<lookup_info oid="3" value="high temperature warning!"/>
-		<lookup_info oid="4" value="high temperature critical!"/>
-	</lookup>
-	<lookup name="marlin_ambient_presence_info">
-		<lookup_info oid="-1" value="unknown"/>
-		<lookup_info oid="0" value="no"/>
-		<lookup_info oid="1" value="yes"/>
-	</lookup>
-	<lookup name="marlin_emp002_ambient_presence_info">
-		<lookup_info oid="0" value="unknown"/>
-		<lookup_info oid="2" value="yes"/>
-		<lookup_info oid="3" value="no"/>
-	</lookup>
-	<lookup name="marlin_threshold_frequency_status_info">
-		<lookup_info oid="0" value="good"/>
-		<lookup_info oid="1" value="out-of-range"/>
-	</lookup>
-	<lookup name="marlin_threshold_voltage_alarms_info">
-		<lookup_info oid="0" value=""/>
-		<lookup_info oid="1" value="low voltage warning!"/>
-		<lookup_info oid="2" value="low voltage critical!"/>
-		<lookup_info oid="3" value="high voltage warning!"/>
-		<lookup_info oid="4" value="high voltage critical!"/>
-	</lookup>
-	<lookup name="marlin_ambient_drycontacts_state_info">
-		<lookup_info oid="0" value="inactive"/>
-		<lookup_info oid="1" value="active"/>
-	</lookup>
-	<lookup name="marlin_outlet_group_type_info">
-		<lookup_info oid="0" value="unknown"/>
-		<lookup_info oid="1" value="breaker1pole"/>
-		<lookup_info oid="2" value="breaker2pole"/>
-		<lookup_info oid="3" value="breaker3pole"/>
-		<lookup_info oid="4" value="outlet-section"/>
-		<lookup_info oid="5" value="user-defined"/>
-	</lookup>
-	<lookup name="eaton_sensor_temperature_unit_info">
-		<lookup_info oid="0" value="kelvin"/>
-		<lookup_info oid="1" value="celsius"/>
-		<lookup_info oid="2" value="fahrenheit"/>
-	</lookup>
-	<lookup name="marlin_outlet_group_phase_info">
-		<lookup_info oid="0" value="unknown"/>
-		<lookup_info oid="1" value="1"/>
-		<lookup_info oid="2" value="1-N"/>
-		<lookup_info oid="3" value="2-N"/>
-		<lookup_info oid="4" value="3-N"/>
-		<lookup_info oid="5" value="1-2"/>
-		<lookup_info oid="6" value="2-3"/>
-		<lookup_info oid="7" value="3-1"/>
-	</lookup>
 	<lookup name="marlin_threshold_frequency_alarm_info">
 		<lookup_info oid="0" value=""/>
 		<lookup_info oid="1" value="frequency out of range!"/>
 	</lookup>
-	<lookup name="marlin_threshold_status_info">
+	<lookup name="marlin_threshold_frequency_status_info">
 		<lookup_info oid="0" value="good"/>
-		<lookup_info oid="1" value="warning-low"/>
-		<lookup_info oid="2" value="critical-low"/>
-		<lookup_info oid="3" value="warning-high"/>
-		<lookup_info oid="4" value="critical-high"/>
-	</lookup>
-	<lookup name="g2_unit_outlet_switchability_info">
-		<lookup_info oid="-1" value="yes"/>
-		<lookup_info oid="0" value="yes"/>
-	</lookup>
-	<lookup name="marlin_outlet_status_info">
-		<lookup_info oid="0" value="off"/>
-		<lookup_info oid="1" value="on"/>
-		<lookup_info oid="2" value="pendingOff"/>
-		<lookup_info oid="3" value="pendingOn"/>
-	</lookup>
-	<lookup name="marlin_outlet_switchability_info">
-		<lookup_info oid="1" value="yes"/>
-		<lookup_info oid="2" value="no"/>
+		<lookup_info oid="1" value="out-of-range"/>
 	</lookup>
 	<lookup name="marlin_threshold_humidity_alarms_info">
 		<lookup_info oid="0" value=""/>
@@ -135,11 +113,33 @@
 		<lookup_info oid="3" value="high humidity warning!"/>
 		<lookup_info oid="4" value="high humidity critical!"/>
 	</lookup>
-	<lookup name="marlin_input_type_info">
-		<lookup_info oid="1" value="1"/>
-		<lookup_info oid="2" value="2"/>
-		<lookup_info oid="3" value="3"/>
-		<lookup_info oid="4" value="3"/>
+	<lookup name="marlin_threshold_status_info">
+		<lookup_info oid="0" value="good"/>
+		<lookup_info oid="1" value="warning-low"/>
+		<lookup_info oid="2" value="critical-low"/>
+		<lookup_info oid="3" value="warning-high"/>
+		<lookup_info oid="4" value="critical-high"/>
+	</lookup>
+	<lookup name="marlin_threshold_temperature_alarms_info">
+		<lookup_info oid="0" value=""/>
+		<lookup_info oid="1" value="low temperature warning!"/>
+		<lookup_info oid="2" value="low temperature critical!"/>
+		<lookup_info oid="3" value="high temperature warning!"/>
+		<lookup_info oid="4" value="high temperature critical!"/>
+	</lookup>
+	<lookup name="marlin_threshold_voltage_alarms_info">
+		<lookup_info oid="0" value=""/>
+		<lookup_info oid="1" value="low voltage warning!"/>
+		<lookup_info oid="2" value="low voltage critical!"/>
+		<lookup_info oid="3" value="high voltage warning!"/>
+		<lookup_info oid="4" value="high voltage critical!"/>
+	</lookup>
+	<lookup name="marlin_unit_switchability_info">
+		<lookup_info oid="0" value="no"/>
+		<lookup_info oid="1" value="yes"/>
+		<lookup_info oid="2" value="no"/>
+		<lookup_info oid="3" value="yes"/>
+		<lookup_info oid="4" value="no"/>
 	</lookup>
 	<snmp name="eaton_marlin_mib">
 		<snmp_info absent="yes" default="EATON" flag_ok="yes" multiplier="128.0" name="device.mfr" static="yes" string="yes"/>

--- a/scripts/DMF/dmfsnmp/eaton-pdu-pulizzi-mib.dmf
+++ b/scripts/DMF/dmfsnmp/eaton-pdu-pulizzi-mib.dmf
@@ -1,12 +1,12 @@
 <?xml version="1.0" ?>
 <nut version="1.0.0" xmlns="http://www.networkupstools.org/dmf/snmp/snmp-ups">
-	<lookup name="pulizzi_sw_outlet_switchability_info">
-		<lookup_info oid="1" value="yes"/>
-		<lookup_info oid="2" value="yes"/>
-	</lookup>
 	<lookup name="pulizzi_sw_outlet_status_info">
 		<lookup_info oid="1" value="on"/>
 		<lookup_info oid="2" value="off"/>
+	</lookup>
+	<lookup name="pulizzi_sw_outlet_switchability_info">
+		<lookup_info oid="1" value="yes"/>
+		<lookup_info oid="2" value="yes"/>
 	</lookup>
 	<snmp name="eaton_pulizzi_switched_mib">
 		<snmp_info absent="yes" default="EATON | Powerware" flag_ok="yes" multiplier="128.0" name="device.mfr" static="yes" string="yes"/>

--- a/scripts/DMF/dmfsnmp/hpe-pdu-mib.dmf
+++ b/scripts/DMF/dmfsnmp/hpe-pdu-mib.dmf
@@ -7,33 +7,10 @@
 		<lookup_info oid="2" value="closed"/>
 		<lookup_info oid="3" value="bad"/>
 	</lookup>
-	<lookup name="hpe_pdu_threshold_humidity_alarms_info">
-		<lookup_info oid="1" value=""/>
-		<lookup_info oid="2" value="low humidity warning!"/>
-		<lookup_info oid="3" value="low humidity critical!"/>
-		<lookup_info oid="4" value="high humidity warning!"/>
-		<lookup_info oid="5" value="high humidity critical!"/>
-	</lookup>
-	<lookup name="hpe_pdu_threshold_current_alarms_info">
-		<lookup_info oid="1" value=""/>
-		<lookup_info oid="2" value="low current warning!"/>
-		<lookup_info oid="3" value="low current critical!"/>
-		<lookup_info oid="4" value="high current warning!"/>
-		<lookup_info oid="5" value="high current critical!"/>
-	</lookup>
-	<lookup name="hpe_pdu_threshold_voltage_alarms_info">
-		<lookup_info oid="1" value=""/>
-		<lookup_info oid="2" value="low voltage warning!"/>
-		<lookup_info oid="3" value="low voltage critical!"/>
-		<lookup_info oid="4" value="high voltage warning!"/>
-		<lookup_info oid="5" value="high voltage critical!"/>
-	</lookup>
-	<lookup name="hpe_pdu_threshold_status_info">
-		<lookup_info oid="1" value="good"/>
-		<lookup_info oid="2" value="warning-low"/>
-		<lookup_info oid="3" value="critical-low"/>
-		<lookup_info oid="4" value="warning-high"/>
-		<lookup_info oid="5" value="critical-high"/>
+	<lookup name="hpe_pdu_ambient_presence_info">
+		<lookup_info oid="-1" value="unknown"/>
+		<lookup_info oid="1" value="no"/>
+		<lookup_info oid="2" value="yes"/>
 	</lookup>
 	<lookup name="hpe_pdu_input_type_info">
 		<lookup_info oid="1" value="1"/>
@@ -41,20 +18,32 @@
 		<lookup_info oid="3" value="3"/>
 		<lookup_info oid="4" value="3"/>
 	</lookup>
-	<lookup name="hpe_pdu_threshold_frequency_alarm_info">
-		<lookup_info oid="1" value=""/>
-		<lookup_info oid="2" value="frequency out of range!"/>
+	<lookup name="hpe_pdu_outlet_group_phase_info">
+		<lookup_info oid="1" value="L1"/>
+		<lookup_info oid="2" value="L1"/>
+		<lookup_info oid="3" value="L2"/>
+		<lookup_info oid="4" value="L3"/>
+		<lookup_info oid="5" value="L1"/>
+		<lookup_info oid="6" value="L2"/>
+		<lookup_info oid="7" value="L3"/>
+	</lookup>
+	<lookup name="hpe_pdu_outlet_group_type_info">
+		<lookup_info oid="0" value="unknown"/>
+		<lookup_info oid="1" value="unknown"/>
+		<lookup_info oid="2" value="breaker1pole"/>
+		<lookup_info oid="3" value="breaker2pole"/>
+		<lookup_info oid="4" value="breaker3pole"/>
+		<lookup_info oid="5" value="outlet-section"/>
+	</lookup>
+	<lookup name="hpe_pdu_outlet_status_info">
+		<lookup_info oid="1" value="off"/>
+		<lookup_info oid="2" value="on"/>
+		<lookup_info oid="3" value="pendingOff"/>
+		<lookup_info oid="4" value="pendingOn"/>
 	</lookup>
 	<lookup name="hpe_pdu_outlet_switchability_info">
 		<lookup_info oid="1" value="yes"/>
 		<lookup_info oid="2" value="no"/>
-	</lookup>
-	<lookup name="hpe_pdu_threshold_temperature_alarms_info">
-		<lookup_info oid="1" value=""/>
-		<lookup_info oid="2" value="low temperature warning!"/>
-		<lookup_info oid="3" value="low temperature critical!"/>
-		<lookup_info oid="4" value="high temperature warning!"/>
-		<lookup_info oid="5" value="high temperature critical!"/>
 	</lookup>
 	<lookup name="hpe_pdu_outlet_type_info">
 		<lookup_info oid="0" value="unknown"/>
@@ -75,42 +64,53 @@
 		<lookup_info oid="29" value="nemaL715"/>
 		<lookup_info oid="30" value="rf203p277"/>
 	</lookup>
-	<lookup name="hpe_pdu_outlet_group_type_info">
-		<lookup_info oid="0" value="unknown"/>
-		<lookup_info oid="1" value="unknown"/>
-		<lookup_info oid="2" value="breaker1pole"/>
-		<lookup_info oid="3" value="breaker2pole"/>
-		<lookup_info oid="4" value="breaker3pole"/>
-		<lookup_info oid="5" value="outlet-section"/>
-	</lookup>
-	<lookup name="hpe_pdu_outlet_group_phase_info">
-		<lookup_info oid="1" value="L1"/>
-		<lookup_info oid="2" value="L1"/>
-		<lookup_info oid="3" value="L2"/>
-		<lookup_info oid="4" value="L3"/>
-		<lookup_info oid="5" value="L1"/>
-		<lookup_info oid="6" value="L2"/>
-		<lookup_info oid="7" value="L3"/>
-	</lookup>
-	<lookup name="hpe_pdu_threshold_frequency_status_info">
-		<lookup_info oid="1" value="good"/>
-		<lookup_info oid="2" value="out-of-range"/>
-	</lookup>
 	<lookup name="hpe_pdu_outletgroups_status_info">
 		<lookup_info oid="1" value="N/A"/>
 		<lookup_info oid="2" value="on"/>
 		<lookup_info oid="3" value="off"/>
 	</lookup>
-	<lookup name="hpe_pdu_outlet_status_info">
-		<lookup_info oid="1" value="off"/>
-		<lookup_info oid="2" value="on"/>
-		<lookup_info oid="3" value="pendingOff"/>
-		<lookup_info oid="4" value="pendingOn"/>
+	<lookup name="hpe_pdu_threshold_current_alarms_info">
+		<lookup_info oid="1" value=""/>
+		<lookup_info oid="2" value="low current warning!"/>
+		<lookup_info oid="3" value="low current critical!"/>
+		<lookup_info oid="4" value="high current warning!"/>
+		<lookup_info oid="5" value="high current critical!"/>
 	</lookup>
-	<lookup name="hpe_pdu_ambient_presence_info">
-		<lookup_info oid="-1" value="unknown"/>
-		<lookup_info oid="1" value="no"/>
-		<lookup_info oid="2" value="yes"/>
+	<lookup name="hpe_pdu_threshold_frequency_alarm_info">
+		<lookup_info oid="1" value=""/>
+		<lookup_info oid="2" value="frequency out of range!"/>
+	</lookup>
+	<lookup name="hpe_pdu_threshold_frequency_status_info">
+		<lookup_info oid="1" value="good"/>
+		<lookup_info oid="2" value="out-of-range"/>
+	</lookup>
+	<lookup name="hpe_pdu_threshold_humidity_alarms_info">
+		<lookup_info oid="1" value=""/>
+		<lookup_info oid="2" value="low humidity warning!"/>
+		<lookup_info oid="3" value="low humidity critical!"/>
+		<lookup_info oid="4" value="high humidity warning!"/>
+		<lookup_info oid="5" value="high humidity critical!"/>
+	</lookup>
+	<lookup name="hpe_pdu_threshold_status_info">
+		<lookup_info oid="1" value="good"/>
+		<lookup_info oid="2" value="warning-low"/>
+		<lookup_info oid="3" value="critical-low"/>
+		<lookup_info oid="4" value="warning-high"/>
+		<lookup_info oid="5" value="critical-high"/>
+	</lookup>
+	<lookup name="hpe_pdu_threshold_temperature_alarms_info">
+		<lookup_info oid="1" value=""/>
+		<lookup_info oid="2" value="low temperature warning!"/>
+		<lookup_info oid="3" value="low temperature critical!"/>
+		<lookup_info oid="4" value="high temperature warning!"/>
+		<lookup_info oid="5" value="high temperature critical!"/>
+	</lookup>
+	<lookup name="hpe_pdu_threshold_voltage_alarms_info">
+		<lookup_info oid="1" value=""/>
+		<lookup_info oid="2" value="low voltage warning!"/>
+		<lookup_info oid="3" value="low voltage critical!"/>
+		<lookup_info oid="4" value="high voltage warning!"/>
+		<lookup_info oid="5" value="high voltage critical!"/>
 	</lookup>
 	<snmp name="hpe_pdu_mib">
 		<snmp_info absent="yes" default="HPE" flag_ok="yes" multiplier="128.0" name="device.mfr" static="yes" string="yes"/>

--- a/scripts/DMF/dmfsnmp/huawei-mib.dmf
+++ b/scripts/DMF/dmfsnmp/huawei-mib.dmf
@@ -1,24 +1,20 @@
 <?xml version="1.0" ?>
 <nut version="1.0.0" xmlns="http://www.networkupstools.org/dmf/snmp/snmp-ups">
-	<lookup name="huawei_voltrating_info">
-		<lookup_info oid="1" value="200"/>
-		<lookup_info oid="2" value="208"/>
-		<lookup_info oid="3" value="220"/>
-		<lookup_info oid="4" value="380"/>
-		<lookup_info oid="5" value="400"/>
-		<lookup_info oid="6" value="415"/>
-		<lookup_info oid="7" value="480"/>
-		<lookup_info oid="8" value="600"/>
-		<lookup_info oid="9" value="690"/>
-	</lookup>
-	<lookup name="huawei_supplymethod_info">
+	<lookup name="huawei_battstate_info">
 		<lookup_info oid="1" value=""/>
-		<lookup_info oid="2" value="OL BYPASS"/>
-		<lookup_info oid="3" value="OL"/>
-		<lookup_info oid="4" value="OB"/>
-		<lookup_info oid="5" value=""/>
-		<lookup_info oid="6" value="OL ECO"/>
-		<lookup_info oid="7" value="OB ECO"/>
+		<lookup_info oid="2" value=""/>
+		<lookup_info oid="3" value=""/>
+		<lookup_info oid="4" value=""/>
+		<lookup_info oid="5" value="CHRG"/>
+		<lookup_info oid="6" value="DISCHRG"/>
+	</lookup>
+	<lookup name="huawei_freqrating_info">
+		<lookup_info oid="1" value="50"/>
+		<lookup_info oid="2" value="60"/>
+	</lookup>
+	<lookup name="huawei_phase_info">
+		<lookup_info oid="1" value="1"/>
+		<lookup_info oid="2" value="3"/>
 	</lookup>
 	<lookup name="huawei_pwrrating_info">
 		<lookup_info oid="1" value="80000"/>
@@ -34,21 +30,14 @@
 		<lookup_info oid="11" value="2800000"/>
 		<lookup_info oid="12" value="3000000"/>
 	</lookup>
-	<lookup name="huawei_battstate_info">
+	<lookup name="huawei_supplymethod_info">
 		<lookup_info oid="1" value=""/>
-		<lookup_info oid="2" value=""/>
-		<lookup_info oid="3" value=""/>
-		<lookup_info oid="4" value=""/>
-		<lookup_info oid="5" value="CHRG"/>
-		<lookup_info oid="6" value="DISCHRG"/>
-	</lookup>
-	<lookup name="huawei_phase_info">
-		<lookup_info oid="1" value="1"/>
-		<lookup_info oid="2" value="3"/>
-	</lookup>
-	<lookup name="huawei_freqrating_info">
-		<lookup_info oid="1" value="50"/>
-		<lookup_info oid="2" value="60"/>
+		<lookup_info oid="2" value="OL BYPASS"/>
+		<lookup_info oid="3" value="OL"/>
+		<lookup_info oid="4" value="OB"/>
+		<lookup_info oid="5" value=""/>
+		<lookup_info oid="6" value="OL ECO"/>
+		<lookup_info oid="7" value="OB ECO"/>
 	</lookup>
 	<lookup name="huawei_test_result_info">
 		<lookup_info oid="1" value="done and passed"/>
@@ -57,6 +46,17 @@
 		<lookup_info oid="4" value="aborted"/>
 		<lookup_info oid="5" value="in progress"/>
 		<lookup_info oid="6" value="no test initiated"/>
+	</lookup>
+	<lookup name="huawei_voltrating_info">
+		<lookup_info oid="1" value="200"/>
+		<lookup_info oid="2" value="208"/>
+		<lookup_info oid="3" value="220"/>
+		<lookup_info oid="4" value="380"/>
+		<lookup_info oid="5" value="400"/>
+		<lookup_info oid="6" value="415"/>
+		<lookup_info oid="7" value="480"/>
+		<lookup_info oid="8" value="600"/>
+		<lookup_info oid="9" value="690"/>
 	</lookup>
 	<snmp name="huawei_mib">
 		<snmp_info absent="yes" default="Huawei" flag_ok="yes" multiplier="128.0" name="ups.mfr" string="yes"/>

--- a/scripts/DMF/dmfsnmp/ietf-mib.dmf
+++ b/scripts/DMF/dmfsnmp/ietf-mib.dmf
@@ -1,24 +1,18 @@
 <?xml version="1.0" ?>
 <nut version="1.0.0" xmlns="http://www.networkupstools.org/dmf/snmp/snmp-ups">
+	<lookup name="ietf_battery_info">
+		<lookup_info oid="1" value=""/>
+		<lookup_info oid="2" value=""/>
+		<lookup_info oid="3" value="LB"/>
+		<lookup_info oid="4" value="LB"/>
+	</lookup>
 	<lookup name="ietf_beeper_status_info">
 		<lookup_info oid="1" value="disabled"/>
 		<lookup_info oid="2" value="enabled"/>
 		<lookup_info oid="3" value="muted"/>
 	</lookup>
-	<lookup name="ietf_test_result_info">
-		<lookup_info oid="1" value="done and passed"/>
-		<lookup_info oid="2" value="done and warning"/>
-		<lookup_info oid="3" value="done and error"/>
-		<lookup_info oid="4" value="aborted"/>
-		<lookup_info oid="5" value="in progress"/>
-		<lookup_info oid="6" value="no test initiated"/>
-	</lookup>
-	<lookup name="ietf_test_active_info">
-		<lookup_info oid="1" value=""/>
-		<lookup_info oid="2" value=""/>
-		<lookup_info oid="3" value="TEST"/>
-		<lookup_info oid="4" value="TEST"/>
-		<lookup_info oid="5" value="CAL"/>
+	<lookup name="ietf_overload_info">
+		<lookup_info oid="1" value="OVER"/>
 	</lookup>
 	<lookup name="ietf_power_source_info">
 		<lookup_info oid="1" value=""/>
@@ -29,14 +23,20 @@
 		<lookup_info oid="6" value="OL BOOST"/>
 		<lookup_info oid="7" value="OL TRIM"/>
 	</lookup>
-	<lookup name="ietf_battery_info">
+	<lookup name="ietf_test_active_info">
 		<lookup_info oid="1" value=""/>
 		<lookup_info oid="2" value=""/>
-		<lookup_info oid="3" value="LB"/>
-		<lookup_info oid="4" value="LB"/>
+		<lookup_info oid="3" value="TEST"/>
+		<lookup_info oid="4" value="TEST"/>
+		<lookup_info oid="5" value="CAL"/>
 	</lookup>
-	<lookup name="ietf_overload_info">
-		<lookup_info oid="1" value="OVER"/>
+	<lookup name="ietf_test_result_info">
+		<lookup_info oid="1" value="done and passed"/>
+		<lookup_info oid="2" value="done and warning"/>
+		<lookup_info oid="3" value="done and error"/>
+		<lookup_info oid="4" value="aborted"/>
+		<lookup_info oid="5" value="in progress"/>
+		<lookup_info oid="6" value="no test initiated"/>
 	</lookup>
 	<lookup name="ietf_yes_no_info">
 		<lookup_info oid="1" value="yes"/>

--- a/scripts/DMF/dmfsnmp/mge-mib.dmf
+++ b/scripts/DMF/dmfsnmp/mge-mib.dmf
@@ -1,51 +1,5 @@
 <?xml version="1.0" ?>
 <nut version="1.0.0" xmlns="http://www.networkupstools.org/dmf/snmp/snmp-ups">
-	<lookup name="mge_power_source_info">
-		<lookup_info oid="1" value=""/>
-		<lookup_info oid="2" value="OFF"/>
-		<lookup_info oid="4" value="BYPASS"/>
-		<lookup_info oid="5" value="OB"/>
-		<lookup_info oid="6" value="BOOST"/>
-		<lookup_info oid="7" value="TRIM"/>
-	</lookup>
-	<lookup name="mge_output_util_off_info">
-		<lookup_info oid="1" value="OFF"/>
-		<lookup_info oid="2" value=""/>
-	</lookup>
-	<lookup name="mge_replacebatt_info">
-		<lookup_info oid="1" value="RB"/>
-		<lookup_info oid="2" value=""/>
-	</lookup>
-	<lookup name="mge_trim_info">
-		<lookup_info oid="1" value="TRIM"/>
-		<lookup_info oid="2" value=""/>
-	</lookup>
-	<lookup name="mge_onbatt_info">
-		<lookup_info oid="1" value="OB"/>
-		<lookup_info oid="2" value="OL"/>
-	</lookup>
-	<lookup name="mge_test_result_info">
-		<lookup_info oid="1" value="done and passed"/>
-		<lookup_info oid="2" value="done and warning"/>
-		<lookup_info oid="3" value="done and error"/>
-		<lookup_info oid="4" value="aborted"/>
-		<lookup_info oid="5" value="in progress"/>
-		<lookup_info oid="6" value="no test initiated"/>
-	</lookup>
-	<lookup name="mge_boost_info">
-		<lookup_info oid="1" value="BOOST"/>
-		<lookup_info oid="2" value=""/>
-	</lookup>
-	<lookup name="mge_transfer_reason_info">
-		<lookup_info oid="1" value=""/>
-		<lookup_info oid="2" value="input voltage out of range"/>
-		<lookup_info oid="3" value="input frequency out of range"/>
-		<lookup_info oid="4" value="utility off"/>
-	</lookup>
-	<lookup name="mge_bypass_info">
-		<lookup_info oid="1" value="BYPASS"/>
-		<lookup_info oid="2" value=""/>
-	</lookup>
 	<lookup name="mge_ambient_drycontacts_info">
 		<lookup_info oid="-1" value="unknown"/>
 		<lookup_info oid="1" value="closed"/>
@@ -56,12 +10,58 @@
 		<lookup_info oid="2" value="enabled"/>
 		<lookup_info oid="3" value="muted"/>
 	</lookup>
+	<lookup name="mge_boost_info">
+		<lookup_info oid="1" value="BOOST"/>
+		<lookup_info oid="2" value=""/>
+	</lookup>
+	<lookup name="mge_bypass_info">
+		<lookup_info oid="1" value="BYPASS"/>
+		<lookup_info oid="2" value=""/>
+	</lookup>
 	<lookup name="mge_lowbatt_info">
 		<lookup_info oid="1" value="LB"/>
 		<lookup_info oid="2" value=""/>
 	</lookup>
+	<lookup name="mge_onbatt_info">
+		<lookup_info oid="1" value="OB"/>
+		<lookup_info oid="2" value="OL"/>
+	</lookup>
+	<lookup name="mge_output_util_off_info">
+		<lookup_info oid="1" value="OFF"/>
+		<lookup_info oid="2" value=""/>
+	</lookup>
 	<lookup name="mge_overload_info">
 		<lookup_info oid="1" value="OVER"/>
+		<lookup_info oid="2" value=""/>
+	</lookup>
+	<lookup name="mge_power_source_info">
+		<lookup_info oid="1" value=""/>
+		<lookup_info oid="2" value="OFF"/>
+		<lookup_info oid="4" value="BYPASS"/>
+		<lookup_info oid="5" value="OB"/>
+		<lookup_info oid="6" value="BOOST"/>
+		<lookup_info oid="7" value="TRIM"/>
+	</lookup>
+	<lookup name="mge_replacebatt_info">
+		<lookup_info oid="1" value="RB"/>
+		<lookup_info oid="2" value=""/>
+	</lookup>
+	<lookup name="mge_test_result_info">
+		<lookup_info oid="1" value="done and passed"/>
+		<lookup_info oid="2" value="done and warning"/>
+		<lookup_info oid="3" value="done and error"/>
+		<lookup_info oid="4" value="aborted"/>
+		<lookup_info oid="5" value="in progress"/>
+		<lookup_info oid="6" value="no test initiated"/>
+	</lookup>
+	<lookup name="mge_transfer_reason_info">
+		<lookup_info oid="1" value=""/>
+		<lookup_info oid="2" value="input voltage out of range"/>
+		<lookup_info oid="3" value="input frequency out of range"/>
+		<lookup_info oid="4" value="utility off"/>
+	</lookup>
+	<lookup name="mge_trim_info">
+		<lookup_info oid="1" value="TRIM"/>
 		<lookup_info oid="2" value=""/>
 	</lookup>
 	<lookup name="mge_yes_no_info">

--- a/scripts/DMF/dmfsnmp/powerware-mib.dmf
+++ b/scripts/DMF/dmfsnmp/powerware-mib.dmf
@@ -1,17 +1,5 @@
 <?xml version="1.0" ?>
 <nut version="1.0.0" xmlns="http://www.networkupstools.org/dmf/snmp/snmp-ups">
-	<lookup name="pw_outlet_status_info">
-		<lookup_info oid="1" value="on"/>
-		<lookup_info oid="2" value="off"/>
-		<lookup_info oid="3" value="on"/>
-		<lookup_info oid="4" value="off"/>
-		<lookup_info oid="7" value="off"/>
-		<lookup_info oid="8" value="on"/>
-	</lookup>
-	<lookup name="pw_alarm_lb">
-		<lookup_info oid="1" value="LB"/>
-		<lookup_info oid="2" value=""/>
-	</lookup>
 	<lookup name="pw_abm_status_info">
 		<lookup_info oid="1" value="charging"/>
 		<lookup_info oid="2" value="discharging"/>
@@ -20,12 +8,78 @@
 		<lookup_info oid="5" value="unknown"/>
 		<lookup_info oid="6" value="disabled"/>
 	</lookup>
+	<lookup name="pw_alarm_lb">
+		<lookup_info oid="1" value="LB"/>
+		<lookup_info oid="2" value=""/>
+	</lookup>
+	<lookup name="pw_alarm_ob">
+		<lookup_info oid="1" value="OB"/>
+		<lookup_info oid="2" value=""/>
+	</lookup>
 	<lookup name="pw_ambient_drycontacts_info">
 		<lookup_info oid="-1" value="unknown"/>
 		<lookup_info oid="1" value="opened"/>
 		<lookup_info oid="2" value="closed"/>
 		<lookup_info oid="3" value="opened"/>
 		<lookup_info oid="4" value="closed"/>
+	</lookup>
+	<lookup name="pw_ambient_drycontacts_polarity_info">
+		<lookup_info oid="0" value="normal-opened"/>
+		<lookup_info oid="1" value="normal-closed"/>
+	</lookup>
+	<lookup name="pw_ambient_drycontacts_state_info">
+		<lookup_info oid="0" value="inactive"/>
+		<lookup_info oid="1" value="active"/>
+	</lookup>
+	<lookup name="pw_batt_test_info">
+		<lookup_info oid="1" value="Unknown"/>
+		<lookup_info oid="2" value="Done and passed"/>
+		<lookup_info oid="3" value="Done and error"/>
+		<lookup_info oid="4" value="In progress"/>
+		<lookup_info oid="5" value="Not supported"/>
+		<lookup_info oid="6" value="Inhibited"/>
+		<lookup_info oid="7" value="Scheduled"/>
+	</lookup>
+	<lookup name="pw_battery_abm_status">
+		<lookup_info oid="1" value="CHRG"/>
+		<lookup_info oid="2" value="DISCHRG"/>
+	</lookup>
+	<lookup name="pw_emp002_ambient_presence_info">
+		<lookup_info oid="0" value="unknown"/>
+		<lookup_info oid="2" value="yes"/>
+		<lookup_info oid="3" value="no"/>
+	</lookup>
+	<lookup name="pw_outlet_status_info">
+		<lookup_info oid="1" value="on"/>
+		<lookup_info oid="2" value="off"/>
+		<lookup_info oid="3" value="on"/>
+		<lookup_info oid="4" value="off"/>
+		<lookup_info oid="7" value="off"/>
+		<lookup_info oid="8" value="on"/>
+	</lookup>
+	<lookup name="pw_pwr_info">
+		<lookup_info oid="1" value=""/>
+		<lookup_info oid="2" value="OFF"/>
+		<lookup_info oid="3" value="OL"/>
+		<lookup_info oid="4" value="BYPASS"/>
+		<lookup_info oid="5" value="OB"/>
+		<lookup_info oid="6" value="OL BOOST"/>
+		<lookup_info oid="7" value="OL TRIM"/>
+		<lookup_info oid="8" value="OL"/>
+		<lookup_info oid="9" value="OL"/>
+		<lookup_info oid="10" value="OL"/>
+		<lookup_info oid="240" value="OB"/>
+		<lookup_info oid="100" value="BYPASS"/>
+		<lookup_info oid="96" value="BYPASS"/>
+		<lookup_info oid="81" value="OL"/>
+		<lookup_info oid="80" value="OL"/>
+		<lookup_info oid="64" value="OL"/>
+		<lookup_info oid="16" value="OFF"/>
+	</lookup>
+	<lookup name="pw_sensor_temperature_unit_info">
+		<lookup_info oid="0" value="kelvin"/>
+		<lookup_info oid="1" value="celsius"/>
+		<lookup_info oid="2" value="fahrenheit"/>
 	</lookup>
 	<lookup name="pw_threshold_humidity_alarms_info">
 		<lookup_info oid="0" value=""/>
@@ -34,13 +88,19 @@
 		<lookup_info oid="3" value="high humidity warning!"/>
 		<lookup_info oid="4" value="high humidity critical!"/>
 	</lookup>
-	<lookup name="pw_ambient_drycontacts_state_info">
-		<lookup_info oid="0" value="inactive"/>
-		<lookup_info oid="1" value="active"/>
+	<lookup name="pw_threshold_status_info">
+		<lookup_info oid="0" value="good"/>
+		<lookup_info oid="1" value="warning-low"/>
+		<lookup_info oid="2" value="critical-low"/>
+		<lookup_info oid="3" value="warning-high"/>
+		<lookup_info oid="4" value="critical-high"/>
 	</lookup>
-	<lookup name="pw_alarm_ob">
-		<lookup_info oid="1" value="OB"/>
-		<lookup_info oid="2" value=""/>
+	<lookup name="pw_threshold_temperature_alarms_info">
+		<lookup_info oid="0" value=""/>
+		<lookup_info oid="1" value="low temperature warning!"/>
+		<lookup_info oid="2" value="low temperature critical!"/>
+		<lookup_info oid="3" value="high temperature warning!"/>
+		<lookup_info oid="4" value="high temperature critical!"/>
 	</lookup>
 	<lookup name="pw_topology_info">
 		<lookup_info oid="0" value=""/>
@@ -65,69 +125,9 @@
 		<lookup_info oid="512" value="Outlet Controller, Single Phase"/>
 		<lookup_info oid="546" value="Dual AC Input Static Switch Module, 3 Phase"/>
 	</lookup>
-	<lookup name="pw_batt_test_info">
-		<lookup_info oid="1" value="Unknown"/>
-		<lookup_info oid="2" value="Done and passed"/>
-		<lookup_info oid="3" value="Done and error"/>
-		<lookup_info oid="4" value="In progress"/>
-		<lookup_info oid="5" value="Not supported"/>
-		<lookup_info oid="6" value="Inhibited"/>
-		<lookup_info oid="7" value="Scheduled"/>
-	</lookup>
-	<lookup name="pw_emp002_ambient_presence_info">
-		<lookup_info oid="0" value="unknown"/>
-		<lookup_info oid="2" value="yes"/>
-		<lookup_info oid="3" value="no"/>
-	</lookup>
-	<lookup name="pw_threshold_temperature_alarms_info">
-		<lookup_info oid="0" value=""/>
-		<lookup_info oid="1" value="low temperature warning!"/>
-		<lookup_info oid="2" value="low temperature critical!"/>
-		<lookup_info oid="3" value="high temperature warning!"/>
-		<lookup_info oid="4" value="high temperature critical!"/>
-	</lookup>
-	<lookup name="pw_threshold_status_info">
-		<lookup_info oid="0" value="good"/>
-		<lookup_info oid="1" value="warning-low"/>
-		<lookup_info oid="2" value="critical-low"/>
-		<lookup_info oid="3" value="warning-high"/>
-		<lookup_info oid="4" value="critical-high"/>
-	</lookup>
-	<lookup name="pw_sensor_temperature_unit_info">
-		<lookup_info oid="0" value="kelvin"/>
-		<lookup_info oid="1" value="celsius"/>
-		<lookup_info oid="2" value="fahrenheit"/>
-	</lookup>
-	<lookup name="pw_ambient_drycontacts_polarity_info">
-		<lookup_info oid="0" value="normal-opened"/>
-		<lookup_info oid="1" value="normal-closed"/>
-	</lookup>
 	<lookup name="pw_yes_no_info">
 		<lookup_info oid="1" value="yes"/>
 		<lookup_info oid="2" value="no"/>
-	</lookup>
-	<lookup name="pw_battery_abm_status">
-		<lookup_info oid="1" value="CHRG"/>
-		<lookup_info oid="2" value="DISCHRG"/>
-	</lookup>
-	<lookup name="pw_pwr_info">
-		<lookup_info oid="1" value=""/>
-		<lookup_info oid="2" value="OFF"/>
-		<lookup_info oid="3" value="OL"/>
-		<lookup_info oid="4" value="BYPASS"/>
-		<lookup_info oid="5" value="OB"/>
-		<lookup_info oid="6" value="OL BOOST"/>
-		<lookup_info oid="7" value="OL TRIM"/>
-		<lookup_info oid="8" value="OL"/>
-		<lookup_info oid="9" value="OL"/>
-		<lookup_info oid="10" value="OL"/>
-		<lookup_info oid="240" value="OB"/>
-		<lookup_info oid="100" value="BYPASS"/>
-		<lookup_info oid="96" value="BYPASS"/>
-		<lookup_info oid="81" value="OL"/>
-		<lookup_info oid="80" value="OL"/>
-		<lookup_info oid="64" value="OL"/>
-		<lookup_info oid="16" value="OFF"/>
 	</lookup>
 	<alarm name="pw_alarms">
 		<info_alarm oid="1.3.6.1.4.1.534.1.7.4" status="LB"/>

--- a/scripts/DMF/dmfsnmp/raritan-px2-mib.dmf
+++ b/scripts/DMF/dmfsnmp/raritan-px2-mib.dmf
@@ -1,10 +1,5 @@
 <?xml version="1.0" ?>
 <nut version="1.0.0" xmlns="http://www.networkupstools.org/dmf/snmp/snmp-ups">
-	<lookup name="raritanpx2_outlet_switchability_info">
-		<lookup_info oid="-1" value="yes"/>
-		<lookup_info oid="1" value="yes"/>
-		<lookup_info oid="2" value="no"/>
-	</lookup>
 	<lookup name="raritanpx2_outlet_status_info">
 		<lookup_info oid="-1" value="unavailable"/>
 		<lookup_info oid="0" value="open"/>
@@ -30,6 +25,11 @@
 		<lookup_info oid="20" value="inSync"/>
 		<lookup_info oid="21" value="outOfSync"/>
 		<lookup_info oid="0" value="NULL"/>
+	</lookup>
+	<lookup name="raritanpx2_outlet_switchability_info">
+		<lookup_info oid="-1" value="yes"/>
+		<lookup_info oid="1" value="yes"/>
+		<lookup_info oid="2" value="no"/>
 	</lookup>
 	<snmp name="raritan_px2_mib">
 		<snmp_info default="Raritan" flag_ok="yes" multiplier="128.0" name="device.mfr" oid=".1.3.6.1.4.1.13742.6.3.2.1.1.2.1" static="yes" string="yes"/>

--- a/scripts/DMF/jsonify-mib.py.in
+++ b/scripts/DMF/jsonify-mib.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!@PYTHON@
 
 # This Python script takes structure contents from existing legacy
 # NUT *-mib.c sources. This is the first stage for DMF generation,

--- a/scripts/DMF/jsonify-mib.py.in
+++ b/scripts/DMF/jsonify-mib.py.in
@@ -6,7 +6,7 @@
 # by anyone interested.
 #
 #    Copyright (C) 2016 Michal Vyskocil <MichalVyskocil@eaton.com>
-#    Copyright (C) 2016 - 2019 Jim Klimov <EvgenyKlimov@eaton.com>
+#    Copyright (C) 2016 - 2021 Jim Klimov <EvgenyKlimov@eaton.com>
 #
 
 from __future__ import print_function

--- a/scripts/DMF/nut_cpp
+++ b/scripts/DMF/nut_cpp
@@ -8,7 +8,7 @@
 # pycparser; also make sure to use no compiler optimizations (-O0 in gcc).
 #
 #    Copyright (C) 2016 Michal Vyskocil <MichalVyskocil@eaton.com>
-#    Copyright (C) 2016 - 2019 Jim Klimov <EvgenyKlimov@eaton.com>
+#    Copyright (C) 2016 - 2021 Jim Klimov <EvgenyKlimov@eaton.com>
 #
 
 [ -n "${CPP-}" ] || CPP="cpp"

--- a/scripts/DMF/xmlify-mib.py.in
+++ b/scripts/DMF/xmlify-mib.py.in
@@ -6,7 +6,7 @@
 #
 #    Copyright (C) 2016 Michal Vyskocil <MichalVyskocil@eaton.com>
 #    Copyright (C) 2016 Carlos Dominguez <CarlosDominguez@eaton.com>
-#    Copyright (C) 2016 - 2019 Jim Klimov <EvgenyKlimov@eaton.com>
+#    Copyright (C) 2016 - 2021 Jim Klimov <EvgenyKlimov@eaton.com>
 #    Copyright (C) 2019 Arnaud Quette <ArnaudQuette@Eaton.com>
 #
 

--- a/scripts/DMF/xmlify-mib.py.in
+++ b/scripts/DMF/xmlify-mib.py.in
@@ -85,7 +85,11 @@ def mkElement (_element, **attrs):
     global doc
     #el = MD.Element (_element)
     el = doc.createElement (_element)
-    for name, value in attrs.items ():
+    # To have reproducible results across platforms and python versions
+    # (2.7 did sort, 3.6 or 3.8 keeps original dict order, etc...), we
+    # enforce sorting here by attribute name, and for same-named attrs
+    # by their value.
+    for name, value in sorted(attrs.items (), key=lambda item: str(item[0]) + "=" + str(item[1])):
         if value is None:
             continue
         el.setAttribute (name, str(value))
@@ -105,7 +109,7 @@ def mk_lookup (inp, root):
         return
 
     debug("INPUT : '%s'" % inp ["INFO"].items() )
-    for name, lookup in inp ["INFO"].items ():
+    for name, lookup in sorted(inp ["INFO"].items (), key=lambda item: str(item[0]) + "=" + str(item[1])):
         lookup_el = mkElement ("lookup", name=name)
         debug ("name= '%s' lookup = '%s' (%d elem)" %(name, lookup, len(lookup) ))
 
@@ -128,7 +132,8 @@ def mk_lookup (inp, root):
 def mk_alarms (inp, root):
     if not "ALARMS-INFO" in inp:
         return
-    for name, lookup in inp ["ALARMS-INFO"].items ():
+
+    for name, lookup in sorted(inp ["ALARMS-INFO"].items (), key=lambda item: str(item[0]) + "=" + str(item[1])):
         lookup_el = mkElement ("alarm", name=name)
         for info in lookup:
             info_el = mkElement ("info_alarm", oid=info ["OID"], status=info ["status_value"], alarm=info ["alarm_value"])
@@ -138,7 +143,8 @@ def mk_alarms (inp, root):
 def mk_snmp (inp, root):
     if not "SNMP-INFO" in inp:
         return
-    for name, lookup in inp ["SNMP-INFO"].items ():
+
+    for name, lookup in sorted(inp ["SNMP-INFO"].items (), key=lambda item: str(item[0]) + "=" + str(item[1])):
         lookup_el = mkElement ("snmp", name=name)
         for info in lookup:
 
@@ -244,8 +250,7 @@ def mk_mib2nut (inp, root):
     if not "MIB2NUT" in inp:
         return
 
-    for name, lookup in inp ["MIB2NUT"].items ():
-
+    for name, lookup in sorted(inp ["MIB2NUT"].items (), key=lambda item: str(item[0]) + "=" + str(item[1])):
         kwargs = dict (name=name)
         for attr, key in (
                 ("oid", "sysOID"),

--- a/scripts/DMF/xmlify-mib.py.in
+++ b/scripts/DMF/xmlify-mib.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!@PYTHON@
 
 # This Python script takes structure contents from JSON markup generated
 # by `jsonify-mib.py` and generates XML DMF structure that can be parsed


### PR DESCRIPTION
Follows up from #135, #137, #138 and that those CI checks missed the changed MIB files that should have been in sync with DMF files.

Also, it seems that newer python3 and/or pycparser does not sort the XML entries for DMF the same way our code did with python2 (alphabetically inside entries). Probably need to add some more options to some call. Under investigation...

UPDATE: Indeed, somewhere around Python 3.6 and 3.8, return of values from dictionaries became not sorted but per original population of values; so explicit sorting is needed as we want reproducible XMLs with minimal diffs over time. This PR now also fixes lookup table orders, which was quite mixed in earlier saved DMF files.