### PR TITLE
Jenkinsfile: use library pipeline code for Coverity related steps (2.4.0)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -524,7 +524,7 @@ OUT="`git status -s`" && [ -z "\$OUT" ] \\
                     }
 
                     stages {
-                        stage('Compile') {
+                        stage('Compile Coverity') {
                             steps {
                                 dir("tmp/build-coverity") {
                                     deleteDir()
@@ -542,7 +542,7 @@ OUT="`git status -s`" && [ -z "\$OUT" ] \\
                             }
                         }
 
-                        stage('Analyse') {
+                        stage('Analyse Coverity') {
                             steps {
                                 script {
                                     coverity.analyse("tmp/build-coverity")


### PR DESCRIPTION
Follows up from structural changes of PR #143 to both parallelize the Coverity checks part with other checks, separated from upload parallelized with push to OBS, and to use the library steps thus including the performance optimizations for Coverity related activities