### PR TITLE
Fix regression on Eaton EMP002 temperature reading (SNMP)

### DIFF
--- a/drivers/eaton-pdu-marlin-mib.c
+++ b/drivers/eaton-pdu-marlin-mib.c
@@ -36,7 +36,7 @@
 /* Eaton PDU-MIB - Marlin MIB
  * ************************** */
 
-#define EATON_MARLIN_MIB_VERSION	"0.58"
+#define EATON_MARLIN_MIB_VERSION	"0.59"
 #define EATON_MARLIN_SYSOID			".1.3.6.1.4.1.534.6.6.7"
 #define EATON_MARLIN_OID_MODEL_NAME	".1.3.6.1.4.1.534.6.6.7.1.2.1.2.0"
 
@@ -1317,7 +1317,7 @@ static snmp_info_t eaton_marlin_mib[] = {
 	{ "ambient.%i.firmware", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.6.8.1.1.2.1.10.%i", "", SU_AMBIENT_TEMPLATE | SU_TYPE_DAISY_MASTER_ONLY, NULL },
 	/* temperatureUnit.1
 	 * MUST be before the temperature data reading! */
-	{ "ambient.%i.temperature.unit", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.6.8.1.2.5.0", "", SU_AMBIENT_TEMPLATE | SU_TYPE_DAISY_MASTER_ONLY, &eaton_sensor_temperature_unit_info[0] },
+	{ "ambient.%i.temperature.unit", 0, 1.0, ".1.3.6.1.4.1.534.6.8.1.2.5.0", "", SU_AMBIENT_TEMPLATE | SU_TYPE_DAISY_MASTER_ONLY, &eaton_sensor_temperature_unit_info[0] },
 	/* temperatureValue.n.1 */
 	{ "ambient.%i.temperature", 0, 0.1, ".1.3.6.1.4.1.534.6.8.1.2.3.1.3.%i.1", "", SU_AMBIENT_TEMPLATE | SU_TYPE_DAISY_MASTER_ONLY,
 #if WITH_SNMP_LKP_FUN

--- a/drivers/powerware-mib.c
+++ b/drivers/powerware-mib.c
@@ -29,7 +29,7 @@
 #include "eaton-pdu-marlin-helpers.h"
 #endif
 
-#define PW_MIB_VERSION "0.98"
+#define PW_MIB_VERSION "0.99"
 
 /* TODO: more sysOID and MIBs support:
  *
@@ -1162,7 +1162,7 @@ static snmp_info_t pw_mib[] = {
 	{ "ambient.%i.firmware", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.6.8.1.1.2.1.10.%i", "", SU_AMBIENT_TEMPLATE, NULL },
 	/* temperatureUnit.1
 	 * MUST be before the temperature data reading! */
-	{ "ambient.%i.temperature.unit", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.6.8.1.2.5.0", "", SU_AMBIENT_TEMPLATE, &pw_sensor_temperature_unit_info[0] },
+	{ "ambient.%i.temperature.unit", 0, 1.0, ".1.3.6.1.4.1.534.6.8.1.2.5.0", "", SU_AMBIENT_TEMPLATE, &pw_sensor_temperature_unit_info[0] },
 	/* temperatureValue.n.1 */
 	{ "ambient.%i.temperature", 0, 0.1, ".1.3.6.1.4.1.534.6.8.1.2.3.1.3.%i.1", "", SU_AMBIENT_TEMPLATE,
 #if WITH_SNMP_LKP_FUN

--- a/scripts/DMF/dmfsnmp/eaton-pdu-marlin-mib.dmf
+++ b/scripts/DMF/dmfsnmp/eaton-pdu-marlin-mib.dmf
@@ -271,7 +271,7 @@
 		<snmp_info ambient="yes" default="" multiplier="1.0" name="ambient.%i.address" oid=".1.3.6.1.4.1.534.6.8.1.1.2.1.4.%i" type_daisy="3"/>
 		<snmp_info ambient="yes" default="" multiplier="1.0" name="ambient.%i.parent.serial" oid=".1.3.6.1.4.1.534.6.8.1.1.2.1.5.%i" string="yes" type_daisy="3"/>
 		<snmp_info ambient="yes" default="" multiplier="1.0" name="ambient.%i.firmware" oid=".1.3.6.1.4.1.534.6.8.1.1.2.1.10.%i" string="yes" type_daisy="3"/>
-		<snmp_info ambient="yes" default="" lookup="eaton_sensor_temperature_unit_info" multiplier="1.0" name="ambient.%i.temperature.unit" oid=".1.3.6.1.4.1.534.6.8.1.2.5.0" string="yes" type_daisy="3"/>
+		<snmp_info ambient="yes" default="" lookup="eaton_sensor_temperature_unit_info" multiplier="1.0" name="ambient.%i.temperature.unit" oid=".1.3.6.1.4.1.534.6.8.1.2.5.0" type_daisy="3"/>
 		<snmp_info ambient="yes" default="" multiplier="0.1" name="ambient.%i.temperature" oid=".1.3.6.1.4.1.534.6.8.1.2.3.1.3.%i.1" type_daisy="3"/>
 		<snmp_info ambient="yes" lookup="marlin_threshold_status_info" multiplier="128.0" name="ambient.%i.temperature.status" oid=".1.3.6.1.4.1.534.6.8.1.2.3.1.1.%i.1" string="yes" type_daisy="3"/>
 		<snmp_info ambient="yes" lookup="marlin_threshold_temperature_alarms_info" multiplier="128.0" name="ups.alarm" oid=".1.3.6.1.4.1.534.6.8.1.2.3.1.1.%i.1" string="yes" type_daisy="3"/>
@@ -377,6 +377,6 @@
 		<snmp_info command="yes" multiplier="1.0" name="outlet.group.%i.load.on.delay" oid=".1.3.6.1.4.1.534.6.6.7.5.6.1.4.%i.%i" outlet_group="yes" type_daisy="1"/>
 		<snmp_info command="yes" multiplier="1.0" name="outlet.group.%i.load.cycle.delay" oid=".1.3.6.1.4.1.534.6.6.7.5.6.1.5.%i.%i" outlet_group="yes" type_daisy="1"/>
 	</snmp>
-	<mib2nut auto_check=".1.3.6.1.4.1.534.6.6.7.1.2.1.2.0" mib_name="eaton_epdu" name="eaton_marlin" oid=".1.3.6.1.4.1.534.6.6.7" snmp_info="eaton_marlin_mib" version="0.58"/>
+	<mib2nut auto_check=".1.3.6.1.4.1.534.6.6.7.1.2.1.2.0" mib_name="eaton_epdu" name="eaton_marlin" oid=".1.3.6.1.4.1.534.6.6.7" snmp_info="eaton_marlin_mib" version="0.59"/>
 </nut>
 

--- a/scripts/DMF/dmfsnmp/powerware-mib.dmf
+++ b/scripts/DMF/dmfsnmp/powerware-mib.dmf
@@ -268,7 +268,7 @@
 		<snmp_info ambient="yes" default="" multiplier="1.0" name="ambient.%i.id" oid=".1.3.6.1.4.1.534.6.8.1.1.2.1.2.%i" string="yes"/>
 		<snmp_info ambient="yes" default="" multiplier="1.0" name="ambient.%i.address" oid=".1.3.6.1.4.1.534.6.8.1.1.2.1.4.%i"/>
 		<snmp_info ambient="yes" default="" multiplier="1.0" name="ambient.%i.firmware" oid=".1.3.6.1.4.1.534.6.8.1.1.2.1.10.%i" string="yes"/>
-		<snmp_info ambient="yes" default="" lookup="pw_sensor_temperature_unit_info" multiplier="1.0" name="ambient.%i.temperature.unit" oid=".1.3.6.1.4.1.534.6.8.1.2.5.0" string="yes"/>
+		<snmp_info ambient="yes" default="" lookup="pw_sensor_temperature_unit_info" multiplier="1.0" name="ambient.%i.temperature.unit" oid=".1.3.6.1.4.1.534.6.8.1.2.5.0"/>
 		<snmp_info ambient="yes" default="" multiplier="0.1" name="ambient.%i.temperature" oid=".1.3.6.1.4.1.534.6.8.1.2.3.1.3.%i.1"/>
 		<snmp_info ambient="yes" lookup="pw_threshold_status_info" multiplier="128.0" name="ambient.%i.temperature.status" oid=".1.3.6.1.4.1.534.6.8.1.2.3.1.1.%i.1" string="yes"/>
 		<snmp_info ambient="yes" lookup="pw_threshold_temperature_alarms_info" multiplier="128.0" name="ups.alarm" oid=".1.3.6.1.4.1.534.6.8.1.2.3.1.1.%i.1" string="yes"/>
@@ -302,7 +302,7 @@
 		<snmp_info command="yes" multiplier="1.0" name="outlet.%i.load.on.delay" oid=".1.3.6.1.4.1.534.1.12.2.1.4.%i" outlet="yes"/>
 		<snmp_info default="" multiplier="1.0" name="ups.alarms" oid="1.3.6.1.4.1.534.1.7.1.0" power_status="yes"/>
 	</snmp>
-	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pw" name="powerware" oid=".1.3.6.1.4.1.534.1" snmp_info="pw_mib" version="0.98"/>
-	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pxgx_ups" name="pxgx_ups" oid=".1.3.6.1.4.1.534.2.12" snmp_info="pw_mib" version="0.98"/>
+	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pw" name="powerware" oid=".1.3.6.1.4.1.534.1" snmp_info="pw_mib" version="0.99"/>
+	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pxgx_ups" name="pxgx_ups" oid=".1.3.6.1.4.1.534.2.12" snmp_info="pw_mib" version="0.99"/>
 </nut>
 


### PR DESCRIPTION
Following the recent addition of the "String reformating function"
(su_find_strval()), a regression appeared on a corner case: when
flagging a data with ST_FLAG_STRING, while the SNMP OID is an int,
and when there is a fun_vp2s() conversion function, a double
conversion is applied, resulting in no value published. This was
limited to one data (temperature.unit)

Signed-off-by: Arnaud Quette <ArnaudQuette@eaton.com>