### PR TITLE
Eaton: add support for EMP002 on ATS16 NM2 with SNMP

### DIFF
--- a/drivers/eaton-ats16-nm2-mib.c
+++ b/drivers/eaton-ats16-nm2-mib.c
@@ -24,8 +24,12 @@
  */
 
 #include "eaton-ats16-nm2-mib.h"
+#if WITH_SNMP_LKP_FUN
+/* FIXME: shared helper code, need to be put in common */
+#include "eaton-pdu-marlin-helpers.h"
+#endif
 
-#define EATON_ATS16_NM2_MIB_VERSION  "0.18"
+#define EATON_ATS16_NM2_MIB_VERSION  "0.20"
 
 #define EATON_ATS16_NM2_SYSOID  ".1.3.6.1.4.1.534.10.2" /* newer Network-M2 */
 #define EATON_ATS16_NM2_MODEL   ".1.3.6.1.4.1.534.10.2.1.2.0"
@@ -198,6 +202,244 @@ static info_lkp_t eaton_ats16_nm2_output_status_info[] = {
 	}
 };
 
+/* Note: all the below *emp002* info should be shared with marlin and powerware! */
+
+#if WITH_SNMP_LKP_FUN
+/* Note: eaton_sensor_temperature_unit_fun() is defined in eaton-pdu-marlin-helpers.c
+ * and su_temperature_read_fun() is in snmp-ups.c
+ * Future work for DMF might provide same-named routines via LUA-C gateway.
+ */
+
+#if WITH_SNMP_LKP_FUN_DUMMY
+/* Temperature unit consideration */
+const char *eaton_sensor_temperature_unit_fun(void *raw_snmp_value) {
+	/* snmp_value here would be a (long*) */
+	NUT_UNUSED_VARIABLE(raw_snmp_value);
+	return "unknown";
+}
+/* FIXME: please DMF, though this should be in snmp-ups.c or equiv. */
+const char *su_temperature_read_fun(void *raw_snmp_value) {
+	/* snmp_value here would be a (long*) */
+	NUT_UNUSED_VARIABLE(raw_snmp_value);
+	return "dummy";
+};
+#endif // WITH_SNMP_LKP_FUN_DUMMY
+
+static info_lkp_t eaton_ats16_nm2_sensor_temperature_unit_info[] = {
+	{ 0, "dummy"
+#if WITH_SNMP_LKP_FUN
+		, eaton_sensor_temperature_unit_fun, NULL, NULL, NULL
+#endif
+	},
+	{ 0, NULL
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	}
+};
+
+static info_lkp_t eaton_ats16_nm2_sensor_temperature_read_info[] = {
+	{ 0, "dummy"
+#if WITH_SNMP_LKP_FUN
+		, su_temperature_read_fun, NULL, NULL, NULL
+#endif
+	},
+	{ 0, NULL
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	}
+};
+
+#else // if not WITH_SNMP_LKP_FUN:
+
+/* FIXME: For now, DMF codebase falls back to old implementation with static
+ * lookup/mapping tables for this, which can easily go into the DMF XML file.
+ */
+static info_lkp_t eaton_ats16_nm2_sensor_temperature_unit_info[] = {
+	{ 0, "kelvin"
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	},
+	{ 1, "celsius"
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	},
+	{ 2, "fahrenheit"
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	},
+	{ 0, NULL
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	}
+};
+
+#endif // WITH_SNMP_LKP_FUN
+
+static info_lkp_t eaton_ats16_nm2_ambient_drycontacts_polarity_info[] = {
+	{ 0, "normal-opened"
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	},
+	{ 1, "normal-closed"
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	},
+	{ 0, NULL
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	}
+};
+
+static info_lkp_t eaton_ats16_nm2_ambient_drycontacts_state_info[] = {
+	{ 0, "inactive"
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	},
+	{ 1, "active"
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	},
+	{ 0, NULL
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	}
+};
+
+static info_lkp_t eaton_ats16_nm2_emp002_ambient_presence_info[] = {
+	{ 0, "unknown"
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	},
+	{ 2, "yes"
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	},     /* communicationOK */
+	{ 3, "no"
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	},      /* communicationLost */
+	{ 0, NULL
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	}
+};
+
+/* extracted from drivers/eaton-pdu-marlin-mib.c -> marlin_threshold_status_info */
+static info_lkp_t eaton_ats16_nm2_threshold_status_info[] = {
+	{ 0, "good"
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	},          /* No threshold triggered */
+	{ 1, "warning-low"
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	},   /* Warning low threshold triggered */
+	{ 2, "critical-low"
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	},  /* Critical low threshold triggered */
+	{ 3, "warning-high"
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	},  /* Warning high threshold triggered */
+	{ 4, "critical-high"
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	}, /* Critical high threshold triggered */
+	{ 0, NULL
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	}
+};
+
+/* extracted from drivers/eaton-pdu-marlin-mib.c -> marlin_threshold_xxx_alarms_info */
+static info_lkp_t eaton_ats16_nm2_threshold_temperature_alarms_info[] = {
+	{ 0, ""
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	},                           /* No threshold triggered */
+	{ 1, "low temperature warning!"
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	},   /* Warning low threshold triggered */
+	{ 2, "low temperature critical!"
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	},  /* Critical low threshold triggered */
+	{ 3, "high temperature warning!"
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	},  /* Warning high threshold triggered */
+	{ 4, "high temperature critical!"
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	}, /* Critical high threshold triggered */
+	{ 0, NULL
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	}
+};
+static info_lkp_t eaton_ats16_nm2_threshold_humidity_alarms_info[] = {
+	{ 0, ""
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	},                        /* No threshold triggered */
+	{ 1, "low humidity warning!"
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	},   /* Warning low threshold triggered */
+	{ 2, "low humidity critical!"
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	},  /* Critical low threshold triggered */
+	{ 3, "high humidity warning!"
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	},  /* Warning high threshold triggered */
+	{ 4, "high humidity critical!"
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	}, /* Critical high threshold triggered */
+	{ 0, NULL
+#if WITH_SNMP_LKP_FUN
+		, NULL, NULL, NULL, NULL
+#endif
+	}
+};
+
 /* EATON_ATS Snmp2NUT lookup table */
 static snmp_info_t eaton_ats16_nm2_mib[] = {
 
@@ -270,6 +512,9 @@ static snmp_info_t eaton_ats16_nm2_mib[] = {
 	{ "ups.status", 0, 1, ".1.3.6.1.4.1.534.10.2.3.3.2.0", NULL, SU_FLAG_OK, eaton_ats16_nm2_output_status_info },
 
 	/* Ambient collection */
+	/* EMP001 (legacy) mapping for EMP002
+	 * Note that NM2 should only be hooked with EMP002, but if any EMP001 was to be
+	 * connected, the value may be off by a factor 10 (to be proven) */
 	/* ats2EnvRemoteTemp.0 = INTEGER: 0 degrees Centigrade */
 	{ "ambient.temperature", 0, 0.1, ".1.3.6.1.4.1.534.10.2.5.1.0", NULL, SU_FLAG_OK, NULL },
 	/* ats2EnvRemoteTempLowerLimit.0 = INTEGER: 5 degrees Centigrade */
@@ -282,6 +527,80 @@ static snmp_info_t eaton_ats16_nm2_mib[] = {
 	{ "ambient.humidity.low", ST_FLAG_RW, 1, ".1.3.6.1.4.1.534.10.2.5.7.0", NULL, SU_FLAG_OK, NULL },
 	/* ats2EnvRemoteHumidityUpperLimit.0 = INTEGER: 90 percent */
 	{ "ambient.humidity.high", ST_FLAG_RW, 1, ".1.3.6.1.4.1.534.10.2.5.8.0", NULL, SU_FLAG_OK, NULL },
+
+	/* EMP002 (EATON EMP MIB) mapping, including daisychain support */
+	/* Warning: indexes start at '1' not '0'! */
+	/* sensorCount.0 */
+	{ "ambient.count", ST_FLAG_RW, 1.0, ".1.3.6.1.4.1.534.6.8.1.1.1.0", "", 0, NULL },
+	/* CommunicationStatus.n */
+	{ "ambient.%i.present", ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.534.6.8.1.1.4.1.1.%i",
+		NULL, SU_AMBIENT_TEMPLATE, &eaton_ats16_nm2_emp002_ambient_presence_info[0] },
+	/* sensorName.n: OctetString EMPDT1H1C2 @1 */
+	{ "ambient.%i.name", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.6.8.1.1.3.1.1.%i", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* sensorManufacturer.n */
+	{ "ambient.%i.mfr", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.6.8.1.1.2.1.6.%i", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* sensorModel.n */
+	{ "ambient.%i.model", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.6.8.1.1.2.1.7.%i", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* sensorSerialNumber.n */
+	{ "ambient.%i.serial", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.6.8.1.1.2.1.9.%i", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* sensorUuid.n */
+	{ "ambient.%i.id", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.6.8.1.1.2.1.2.%i", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* sensorAddress.n */
+	{ "ambient.%i.address", 0, 1, ".1.3.6.1.4.1.534.6.8.1.1.2.1.4.%i", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* sensorFirmwareVersion.n */
+	{ "ambient.%i.firmware", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.6.8.1.1.2.1.10.%i", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* temperatureUnit.1
+	 * MUST be before the temperature data reading! */
+	{ "ambient.%i.temperature.unit", 0, 1.0, ".1.3.6.1.4.1.534.6.8.1.2.5.0", "", SU_AMBIENT_TEMPLATE, &eaton_ats16_nm2_sensor_temperature_unit_info[0] },
+	/* temperatureValue.n.1 */
+	{ "ambient.%i.temperature", 0, 0.1, ".1.3.6.1.4.1.534.6.8.1.2.3.1.3.%i.1", "", SU_AMBIENT_TEMPLATE,
+#if WITH_SNMP_LKP_FUN
+	&eaton_ats16_nm2_sensor_temperature_read_info[0]
+#else
+	NULL
+#endif
+	},
+	{ "ambient.%i.temperature.status", ST_FLAG_STRING, SU_INFOSIZE,
+		".1.3.6.1.4.1.534.6.8.1.2.3.1.1.%i.1",
+		NULL, SU_AMBIENT_TEMPLATE, &eaton_ats16_nm2_threshold_status_info[0] },
+	{ "ups.alarm", ST_FLAG_STRING, SU_INFOSIZE,
+		".1.3.6.1.4.1.534.6.8.1.2.3.1.1.%i.1",
+		NULL, SU_AMBIENT_TEMPLATE, &eaton_ats16_nm2_threshold_temperature_alarms_info[0] },
+	/* FIXME: ambient.n.temperature.{minimum,maximum} */
+	/* temperatureThresholdLowCritical.n.1 */
+	{ "ambient.%i.temperature.low.critical", ST_FLAG_RW, 0.1, ".1.3.6.1.4.1.534.6.8.1.2.2.1.6.%i.1", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* temperatureThresholdLowWarning.n.1 */
+	{ "ambient.%i.temperature.low.warning", ST_FLAG_RW, 0.1, ".1.3.6.1.4.1.534.6.8.1.2.2.1.5.%i.1", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* temperatureThresholdHighWarning.n.1 */
+	{ "ambient.%i.temperature.high.warning", ST_FLAG_RW, 0.1, ".1.3.6.1.4.1.534.6.8.1.2.2.1.7.%i.1", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* temperatureThresholdHighCritical.n.1 */
+	{ "ambient.%i.temperature.high.critical", ST_FLAG_RW, 0.1, ".1.3.6.1.4.1.534.6.8.1.2.2.1.8.%i.1", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* humidityValue.n.1 */
+	{ "ambient.%i.humidity", 0, 0.1, ".1.3.6.1.4.1.534.6.8.1.3.3.1.3.%i.1", "", SU_AMBIENT_TEMPLATE, NULL },
+	{ "ambient.%i.humidity.status", ST_FLAG_STRING, SU_INFOSIZE,
+		".1.3.6.1.4.1.534.6.8.1.3.3.1.1.%i.1",
+		NULL, SU_AMBIENT_TEMPLATE, &eaton_ats16_nm2_threshold_status_info[0] },
+	{ "ups.alarm", ST_FLAG_STRING, SU_INFOSIZE,
+		".1.3.6.1.4.1.534.6.8.1.3.3.1.1.%i.1",
+		NULL, SU_AMBIENT_TEMPLATE, &eaton_ats16_nm2_threshold_humidity_alarms_info[0] },
+	/* FIXME: consider ambient.n.humidity.{minimum,maximum} */
+	/* humidityThresholdLowCritical.n.1 */
+	{ "ambient.%i.humidity.low.critical", ST_FLAG_RW, 0.1, ".1.3.6.1.4.1.534.6.8.1.3.2.1.6.%i.1", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* humidityThresholdLowWarning.n.1 */
+	{ "ambient.%i.humidity.low.warning", ST_FLAG_RW, 0.1, ".1.3.6.1.4.1.534.6.8.1.3.2.1.5.%i.1", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* humidityThresholdHighWarning.n.1 */
+	{ "ambient.%i.humidity.high.warning", ST_FLAG_RW, 0.1, ".1.3.6.1.4.1.534.6.8.1.3.2.1.7.%i.1", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* humidityThresholdHighCritical.n.1 */
+	{ "ambient.%i.humidity.high.critical", ST_FLAG_RW, 0.1, ".1.3.6.1.4.1.534.6.8.1.3.2.1.8.%i.1", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* digitalInputName.n.{1,2} */
+	{ "ambient.%i.contacts.1.name", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.6.8.1.4.2.1.1.%i.1", "", SU_AMBIENT_TEMPLATE, NULL },
+	{ "ambient.%i.contacts.2.name", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.6.8.1.4.2.1.1.%i.2", "", SU_AMBIENT_TEMPLATE, NULL },
+	/* digitalInputPolarity.n */
+	{ "ambient.%i.contacts.1.config", ST_FLAG_RW | ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.534.6.8.1.4.2.1.3.%i.1", "", SU_AMBIENT_TEMPLATE, &eaton_ats16_nm2_ambient_drycontacts_polarity_info[0] },
+	{ "ambient.%i.contacts.2.config", ST_FLAG_RW | ST_FLAG_STRING, SU_INFOSIZE, ".1.3.6.1.4.1.534.6.8.1.4.2.1.3.%i.2", "", SU_AMBIENT_TEMPLATE, &eaton_ats16_nm2_ambient_drycontacts_polarity_info[0] },
+	/* XUPS-MIB::xupsContactState.n */
+	{ "ambient.%i.contacts.1.status", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.6.8.1.4.3.1.3.%i.1", "", SU_AMBIENT_TEMPLATE, &eaton_ats16_nm2_ambient_drycontacts_state_info[0] },
+	{ "ambient.%i.contacts.2.status", ST_FLAG_STRING, 1.0, ".1.3.6.1.4.1.534.6.8.1.4.3.1.3.%i.2", "", SU_AMBIENT_TEMPLATE, &eaton_ats16_nm2_ambient_drycontacts_state_info[0] },
 
 #if 0 /* FIXME: Remaining data to be processed */
 	/* ats2InputStatusDephasing.0 = INTEGER: normal(1) */

--- a/scripts/DMF/dmfsnmp/eaton-ats16-nm2-mib.dmf
+++ b/scripts/DMF/dmfsnmp/eaton-ats16-nm2-mib.dmf
@@ -1,5 +1,18 @@
 <?xml version="1.0" ?>
 <nut version="1.0.0" xmlns="http://www.networkupstools.org/dmf/snmp/snmp-ups">
+	<lookup name="eaton_ats16_nm2_ambient_drycontacts_polarity_info">
+		<lookup_info oid="0" value="normal-opened"/>
+		<lookup_info oid="1" value="normal-closed"/>
+	</lookup>
+	<lookup name="eaton_ats16_nm2_ambient_drycontacts_state_info">
+		<lookup_info oid="0" value="inactive"/>
+		<lookup_info oid="1" value="active"/>
+	</lookup>
+	<lookup name="eaton_ats16_nm2_emp002_ambient_presence_info">
+		<lookup_info oid="0" value="unknown"/>
+		<lookup_info oid="2" value="yes"/>
+		<lookup_info oid="3" value="no"/>
+	</lookup>
 	<lookup name="eaton_ats16_nm2_input_frequency_status_info">
 		<lookup_info oid="1" value="good"/>
 		<lookup_info oid="2" value="out-of-range"/>
@@ -19,6 +32,11 @@
 		<lookup_info oid="2" value="high"/>
 		<lookup_info oid="3" value="low"/>
 	</lookup>
+	<lookup name="eaton_ats16_nm2_sensor_temperature_unit_info">
+		<lookup_info oid="0" value="kelvin"/>
+		<lookup_info oid="1" value="celsius"/>
+		<lookup_info oid="2" value="fahrenheit"/>
+	</lookup>
 	<lookup name="eaton_ats16_nm2_source_info">
 		<lookup_info oid="1" value="init"/>
 		<lookup_info oid="2" value="diagnosis"/>
@@ -35,6 +53,27 @@
 		<lookup_info oid="4" value="aborted"/>
 		<lookup_info oid="5" value="in progress"/>
 		<lookup_info oid="6" value="no test initiated"/>
+	</lookup>
+	<lookup name="eaton_ats16_nm2_threshold_humidity_alarms_info">
+		<lookup_info oid="0" value=""/>
+		<lookup_info oid="1" value="low humidity warning!"/>
+		<lookup_info oid="2" value="low humidity critical!"/>
+		<lookup_info oid="3" value="high humidity warning!"/>
+		<lookup_info oid="4" value="high humidity critical!"/>
+	</lookup>
+	<lookup name="eaton_ats16_nm2_threshold_status_info">
+		<lookup_info oid="0" value="good"/>
+		<lookup_info oid="1" value="warning-low"/>
+		<lookup_info oid="2" value="critical-low"/>
+		<lookup_info oid="3" value="warning-high"/>
+		<lookup_info oid="4" value="critical-high"/>
+	</lookup>
+	<lookup name="eaton_ats16_nm2_threshold_temperature_alarms_info">
+		<lookup_info oid="0" value=""/>
+		<lookup_info oid="1" value="low temperature warning!"/>
+		<lookup_info oid="2" value="low temperature critical!"/>
+		<lookup_info oid="3" value="high temperature warning!"/>
+		<lookup_info oid="4" value="high temperature critical!"/>
 	</lookup>
 	<lookup name="su_convert_to_iso_date_info">
 		<lookup_info oid="1" value="dummy"/>
@@ -72,7 +111,37 @@
 		<snmp_info flag_ok="yes" multiplier="0.1" name="ambient.humidity" oid=".1.3.6.1.4.1.534.10.2.5.2.0"/>
 		<snmp_info flag_ok="yes" multiplier="1.0" name="ambient.humidity.low" oid=".1.3.6.1.4.1.534.10.2.5.7.0" writable="yes"/>
 		<snmp_info flag_ok="yes" multiplier="1.0" name="ambient.humidity.high" oid=".1.3.6.1.4.1.534.10.2.5.8.0" writable="yes"/>
+		<snmp_info default="" multiplier="1.0" name="ambient.count" oid=".1.3.6.1.4.1.534.6.8.1.1.1.0" power_status="yes" writable="yes"/>
+		<snmp_info ambient="yes" lookup="eaton_ats16_nm2_emp002_ambient_presence_info" multiplier="128.0" name="ambient.%i.present" oid=".1.3.6.1.4.1.534.6.8.1.1.4.1.1.%i" string="yes"/>
+		<snmp_info ambient="yes" default="" multiplier="1.0" name="ambient.%i.name" oid=".1.3.6.1.4.1.534.6.8.1.1.3.1.1.%i" string="yes"/>
+		<snmp_info ambient="yes" default="" multiplier="1.0" name="ambient.%i.mfr" oid=".1.3.6.1.4.1.534.6.8.1.1.2.1.6.%i" string="yes"/>
+		<snmp_info ambient="yes" default="" multiplier="1.0" name="ambient.%i.model" oid=".1.3.6.1.4.1.534.6.8.1.1.2.1.7.%i" string="yes"/>
+		<snmp_info ambient="yes" default="" multiplier="1.0" name="ambient.%i.serial" oid=".1.3.6.1.4.1.534.6.8.1.1.2.1.9.%i" string="yes"/>
+		<snmp_info ambient="yes" default="" multiplier="1.0" name="ambient.%i.id" oid=".1.3.6.1.4.1.534.6.8.1.1.2.1.2.%i" string="yes"/>
+		<snmp_info ambient="yes" default="" multiplier="1.0" name="ambient.%i.address" oid=".1.3.6.1.4.1.534.6.8.1.1.2.1.4.%i"/>
+		<snmp_info ambient="yes" default="" multiplier="1.0" name="ambient.%i.firmware" oid=".1.3.6.1.4.1.534.6.8.1.1.2.1.10.%i" string="yes"/>
+		<snmp_info ambient="yes" default="" lookup="eaton_ats16_nm2_sensor_temperature_unit_info" multiplier="1.0" name="ambient.%i.temperature.unit" oid=".1.3.6.1.4.1.534.6.8.1.2.5.0"/>
+		<snmp_info ambient="yes" default="" multiplier="0.1" name="ambient.%i.temperature" oid=".1.3.6.1.4.1.534.6.8.1.2.3.1.3.%i.1"/>
+		<snmp_info ambient="yes" lookup="eaton_ats16_nm2_threshold_status_info" multiplier="128.0" name="ambient.%i.temperature.status" oid=".1.3.6.1.4.1.534.6.8.1.2.3.1.1.%i.1" string="yes"/>
+		<snmp_info ambient="yes" lookup="eaton_ats16_nm2_threshold_temperature_alarms_info" multiplier="128.0" name="ups.alarm" oid=".1.3.6.1.4.1.534.6.8.1.2.3.1.1.%i.1" string="yes"/>
+		<snmp_info ambient="yes" default="" multiplier="0.1" name="ambient.%i.temperature.low.critical" oid=".1.3.6.1.4.1.534.6.8.1.2.2.1.6.%i.1" writable="yes"/>
+		<snmp_info ambient="yes" default="" multiplier="0.1" name="ambient.%i.temperature.low.warning" oid=".1.3.6.1.4.1.534.6.8.1.2.2.1.5.%i.1" writable="yes"/>
+		<snmp_info ambient="yes" default="" multiplier="0.1" name="ambient.%i.temperature.high.warning" oid=".1.3.6.1.4.1.534.6.8.1.2.2.1.7.%i.1" writable="yes"/>
+		<snmp_info ambient="yes" default="" multiplier="0.1" name="ambient.%i.temperature.high.critical" oid=".1.3.6.1.4.1.534.6.8.1.2.2.1.8.%i.1" writable="yes"/>
+		<snmp_info ambient="yes" default="" multiplier="0.1" name="ambient.%i.humidity" oid=".1.3.6.1.4.1.534.6.8.1.3.3.1.3.%i.1"/>
+		<snmp_info ambient="yes" lookup="eaton_ats16_nm2_threshold_status_info" multiplier="128.0" name="ambient.%i.humidity.status" oid=".1.3.6.1.4.1.534.6.8.1.3.3.1.1.%i.1" string="yes"/>
+		<snmp_info ambient="yes" lookup="eaton_ats16_nm2_threshold_humidity_alarms_info" multiplier="128.0" name="ups.alarm" oid=".1.3.6.1.4.1.534.6.8.1.3.3.1.1.%i.1" string="yes"/>
+		<snmp_info ambient="yes" default="" multiplier="0.1" name="ambient.%i.humidity.low.critical" oid=".1.3.6.1.4.1.534.6.8.1.3.2.1.6.%i.1" writable="yes"/>
+		<snmp_info ambient="yes" default="" multiplier="0.1" name="ambient.%i.humidity.low.warning" oid=".1.3.6.1.4.1.534.6.8.1.3.2.1.5.%i.1" writable="yes"/>
+		<snmp_info ambient="yes" default="" multiplier="0.1" name="ambient.%i.humidity.high.warning" oid=".1.3.6.1.4.1.534.6.8.1.3.2.1.7.%i.1" writable="yes"/>
+		<snmp_info ambient="yes" default="" multiplier="0.1" name="ambient.%i.humidity.high.critical" oid=".1.3.6.1.4.1.534.6.8.1.3.2.1.8.%i.1" writable="yes"/>
+		<snmp_info ambient="yes" default="" multiplier="1.0" name="ambient.%i.contacts.1.name" oid=".1.3.6.1.4.1.534.6.8.1.4.2.1.1.%i.1" string="yes"/>
+		<snmp_info ambient="yes" default="" multiplier="1.0" name="ambient.%i.contacts.2.name" oid=".1.3.6.1.4.1.534.6.8.1.4.2.1.1.%i.2" string="yes"/>
+		<snmp_info ambient="yes" default="" lookup="eaton_ats16_nm2_ambient_drycontacts_polarity_info" multiplier="128.0" name="ambient.%i.contacts.1.config" oid=".1.3.6.1.4.1.534.6.8.1.4.2.1.3.%i.1" string="yes" writable="yes"/>
+		<snmp_info ambient="yes" default="" lookup="eaton_ats16_nm2_ambient_drycontacts_polarity_info" multiplier="128.0" name="ambient.%i.contacts.2.config" oid=".1.3.6.1.4.1.534.6.8.1.4.2.1.3.%i.2" string="yes" writable="yes"/>
+		<snmp_info ambient="yes" default="" lookup="eaton_ats16_nm2_ambient_drycontacts_state_info" multiplier="1.0" name="ambient.%i.contacts.1.status" oid=".1.3.6.1.4.1.534.6.8.1.4.3.1.3.%i.1" string="yes"/>
+		<snmp_info ambient="yes" default="" lookup="eaton_ats16_nm2_ambient_drycontacts_state_info" multiplier="1.0" name="ambient.%i.contacts.2.status" oid=".1.3.6.1.4.1.534.6.8.1.4.3.1.3.%i.2" string="yes"/>
 	</snmp>
-	<mib2nut auto_check=".1.3.6.1.4.1.534.10.2.1.2.0" mib_name="eaton_ats16_nm2" name="eaton_ats16_nm2" oid=".1.3.6.1.4.1.534.10.2" snmp_info="eaton_ats16_nm2_mib" version="0.18"/>
+	<mib2nut auto_check=".1.3.6.1.4.1.534.10.2.1.2.0" mib_name="eaton_ats16_nm2" name="eaton_ats16_nm2" oid=".1.3.6.1.4.1.534.10.2" snmp_info="eaton_ats16_nm2_mib" version="0.20"/>
 </nut>
 


### PR DESCRIPTION
This support is identical to what is in Eaton Marlin
and Powerware MIBs. Future improvements should consider
putting these bits in a common eaton-sensor-mib file,
to avoid multiple definition of the same MIB structure!

Signed-off-by: Arnaud Quette <ArnaudQuette@eaton.com>