### PR TITLE
Redefine bit-flag map values for snmp-ups.h in DMF/FTY codebase

### DIFF
--- a/common/dmfsnmp.c
+++ b/common/dmfsnmp.c
@@ -90,7 +90,7 @@ print_snmp_memory_struct(snmp_info_t *self)
 		}
 	}
 	upsdebugx(5, "*-*-*-->Info_flags %d", self->info_flags);
-	upsdebugx(5, "*-*-*-->Flags %lu", self->flags);
+	upsdebugx(5, "*-*-*-->Flags %" PRI_SU_FLAGS, self->flags);
 
 #if WITH_DMF_FUNCTIONS
 	if(self->function_code){

--- a/drivers/powerware-mib.c
+++ b/drivers/powerware-mib.c
@@ -29,7 +29,7 @@
 #include "eaton-pdu-marlin-helpers.h"
 #endif
 
-#define PW_MIB_VERSION "0.99"
+#define PW_MIB_VERSION "1.00"
 
 /* TODO: more sysOID and MIBs support:
  *
@@ -929,7 +929,7 @@ static snmp_info_t pw_mib[] = {
 	{ "ups.serial", ST_FLAG_STRING, SU_INFOSIZE, IETF_OID_IDENT, "",
 		SU_FLAG_STATIC, NULL },
 	{ "ups.load", 0, 1.0, PW_OID_OUT_LOAD, "",
-		SU_OUTPUT_1, NULL },
+		0, NULL },
 	/* FIXME: should be removed in favor of output.power */
 	{ "ups.power", 0, 1.0, PW_OID_OUT_POWER ".1", "",
 		0, NULL },

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -258,6 +258,17 @@ void upsdrv_initinfo(void)
 	 * outlet (and groups) commands are processed later, during initial walk */
 	for (su_info_p = &snmp_info[0]; (su_info_p != NULL && su_info_p->info_type != NULL) ; su_info_p++)
 	{
+		if (su_info_p->flags == 0UL) {
+			upsdebugx(0,
+				"SNMP UPS driver: %s: MIB2NUT mapping '%s' (OID '%s') did not define flags bits. "
+				"Please report as a bug to the NUT maintainers.",
+				__func__,
+				(su_info_p->info_type ? su_info_p->info_type : "<null>"),
+				(su_info_p->OID ? su_info_p->OID : "<null>")
+				);
+			/* FIXME? Bail out of driver here? Ignore the entry? */
+		}
+
 		su_info_p->flags |= SU_FLAG_OK;
 		if ((SU_TYPE(su_info_p) == SU_TYPE_CMD)
 			&& !(su_info_p->flags & SU_OUTLET)

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -2041,10 +2041,19 @@ bool_t load_mib2nut(const char *mib)
 			snmp_info = mib2nut[i]->snmp_info;
 
 			if (snmp_info == NULL) {
+#if WITH_DMFMIB
+				upsdebugx(0, "%s: WARNING: snmp_info is not initialized "
+					"for mapping table entry #%d \"%s\""
+					", did you load DMF file(s) from correct directory? "
+					"(used '%s')",
+					__func__, i, mib2nut[i]->mib_name, dmf_dir
+					);
+#else /* not WITH_DMFMIB */
 				upsdebugx(0, "%s: WARNING: snmp_info is not initialized "
 					"for mapping table entry #%d \"%s\"",
 					__func__, i, mib2nut[i]->mib_name
 					);
+#endif
 				continue;
 			}
 			else if (snmp_info[0].info_type == NULL) {

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -1944,10 +1944,19 @@ static mib2nut_info_t *match_sysoid()
 				snmp_info = mib2nut[i]->snmp_info;
 
 				if (snmp_info == NULL) {
+#if WITH_DMFMIB
+					upsdebugx(0, "%s: WARNING: snmp_info is not initialized "
+						"for mapping table entry #%d \"%s\""
+						", did you load DMF file(s) from correct directory? "
+						"(used '%s')",
+						__func__, i, mib2nut[i]->mib_name, dmf_dir
+						);
+#else /* not WITH_DMFMIB */
 					upsdebugx(0, "%s: WARNING: snmp_info is not initialized "
 						"for mapping table entry #%d \"%s\"",
 						__func__, i, mib2nut[i]->mib_name
 						);
+#endif
 					continue;
 				}
 				else if (snmp_info[0].info_type == NULL) {

--- a/drivers/snmp-ups.c
+++ b/drivers/snmp-ups.c
@@ -259,14 +259,14 @@ void upsdrv_initinfo(void)
 	for (su_info_p = &snmp_info[0]; (su_info_p != NULL && su_info_p->info_type != NULL) ; su_info_p++)
 	{
 		if (su_info_p->flags == 0UL) {
-			upsdebugx(0,
+			upsdebugx(4,
 				"SNMP UPS driver: %s: MIB2NUT mapping '%s' (OID '%s') did not define flags bits. "
-				"Please report as a bug to the NUT maintainers.",
+				"Entry would be treated as SU_FLAG_OK if available in returned data.",
 				__func__,
 				(su_info_p->info_type ? su_info_p->info_type : "<null>"),
 				(su_info_p->OID ? su_info_p->OID : "<null>")
 				);
-			/* FIXME? Bail out of driver here? Ignore the entry? */
+			/* Treat as OK if avail, otherwise discarded */
 		}
 
 		su_info_p->flags |= SU_FLAG_OK;

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -299,8 +299,8 @@ typedef struct {
 /* "flags" bits 21..23 */
 #define SU_TYPE_DAISY_1		(1UL << 21)	/* Daisychain index is the 1st specifier */
 #define SU_TYPE_DAISY_2		(1UL << 22)	/* Daisychain index is the 2nd specifier */
-#define SU_TYPE_DAISY(t)	((t)->flags & (7UL << 21))	/* FIXME? Mask with 7 or 3 here? */
-#define SU_DAISY			(1UL << 23)	/* Daisychain template definition */
+#define SU_TYPE_DAISY(t)	((t)->flags & (11UL << 21))	/* Mask the 3 SU_TYPE_DAISY_* but not SU_DAISY */
+#define SU_DAISY			(1UL << 23)	/* Daisychain template definition - set at run-time for devices with detected "device.count" over 1 */
 /* NOTE: Previously SU_DAISY had same bit-flag value as SU_TYPE_DAISY_2*/
 #define SU_TYPE_DAISY_MASTER_ONLY	(1UL << 24) /* Only valid for daisychain master (device.1) */
 

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -234,7 +234,7 @@ typedef struct {
 #endif
 } snmp_info_t;
 
-/* "flags" bits 0..8 (and 9 reserved for DMF) */
+/* "flags" bits 0..9 */
 #define SU_FLAG_OK			(1UL << 0)	/* show element to upsd -
 										 * internal to snmp driver */
 #define SU_FLAG_STATIC		(1UL << 1)	/* retrieve info only once. */
@@ -253,10 +253,8 @@ typedef struct {
 #define SU_FLAG_NAINVALID	(1UL << 7)	/* Invalid if "N/A" value */
 #define SU_CMD_OFFSET		(1UL << 8)	/* Add +1 to the OID index */
 
-//#if WITH_DMF_FUNCTIONS
-//#define SU_FLAG_FUNCTION	(1 << 9)	/* TODO Pending to check if this flag have any incompatibility*/
-//#endif
-/* Reserved slot (1UL << 9) -- to import SU_FLAG_FUNCTION from DMF branch codebase */
+#define SU_FLAG_SEMI_STATIC	(1UL << 9) /* Refresh this entry once in several walks
+ * (for R/W values user can set on device, like descriptions or contacts) */
 
 /* Notes on outlet templates usage:
  * - outlet.count MUST exist and MUST be declared before any outlet template
@@ -304,24 +302,25 @@ typedef struct {
 #define SU_TYPE_DAISY(t)	((t)->flags & (7UL << 21))	/* FIXME? Mask with 7 or 3 here? */
 #define SU_DAISY			(1UL << 23)	/* Daisychain template definition */
 /* NOTE: Previously SU_DAISY had same bit-flag value as SU_TYPE_DAISY_2*/
+#define SU_TYPE_DAISY_MASTER_ONLY	(1UL << 24) /* Only valid for daisychain master (device.1) */
 
-/* Definitions from DMF branch, 42ITy fork */
-//#define SU_AMBIENT_TEMPLATE	(1 << 6)	/* ambient template definition */
-//#define SU_FLAG_SEMI_STATIC	(1 << 22) /* Refresh this entry once in several walks
-// * (for R/W values user can set on device, like descriptions or contacts) */
-//#define SU_TYPE_DAISY_MASTER_ONLY	(1 << 23) /* Only valid for daisychain master (device.1) */
+#define SU_AMBIENT_TEMPLATE	(1UL << 26)	/* ambient template definition */
+
+#if WITH_DMF_FUNCTIONS
+#define SU_FLAG_FUNCTION	(1UL << 27)	/* TODO Pending to check if this flag have any incompatibility*/
+#endif
 
 /* status string components
  * FIXME: these should be removed, since there is no added value.
  * Ie, this can be guessed from info->type! */
 
-/* "flags" bits 24..27 */
-#define SU_STATUS_PWR		(1UL << 24)	/* indicates power status element */
-#define SU_STATUS_BATT		(1UL << 25)	/* indicates battery status element */
-#define SU_STATUS_CAL		(1UL << 26)	/* indicates calibration status element */
-#define SU_STATUS_RB		(1UL << 27)	/* indicates replace battery status element */
+/* "flags" bits 28..31 */
+#define SU_STATUS_PWR		(1UL << 28)	/* indicates power status element */
+#define SU_STATUS_BATT		(1UL << 29)	/* indicates battery status element */
+#define SU_STATUS_CAL		(1UL << 30)	/* indicates calibration status element */
+#define SU_STATUS_RB		(1UL << 31)	/* indicates replace battery status element */
 #define SU_STATUS_NUM_ELEM	4			/* Obsolete? No references found in codebase */
-#define SU_STATUS_INDEX(t)	(((unsigned long)(t) >> 24) & 15UL)
+#define SU_STATUS_INDEX(t)	(((unsigned long)(t) >> 28) & 15UL)
 
 /* Despite similar names, definitons below are not among the bit-flags ;) */
 #define SU_VAR_COMMUNITY	"community"

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -220,6 +220,8 @@ typedef struct {
 	                           * NOTE that some *-mib.c mappings can specify
 	                           * a zero in this field... better fix that in
 	                           * favor of explicit values with a meaning!
+	                           * Current code treats such zero values as
+	                           * "OK if avail, otherwise discarded".
 	                           * NOTE: With C99+ a "long" is guaranteed to be
 	                           * at least 4 bytes; consider "unsigned long long"
 	                           * when/if we get more than 32 flag values.

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -248,15 +248,15 @@ typedef struct {
 #define SU_FLAG_UNIQUE		(1UL << 5)	/* There can be only be one
 						 				 * provider of this info,
 						 				 * disable the other providers */
-/* Free slot (used by SU_AMBIENT_TEMPLATE in DMF branch)
- * Note: older releases defined the following flag, but removed it by 2.7.5:
+/* Note: older releases defined the following flag, but removed it by 2.7.5:
  * #define SU_FLAG_SETINT	(1UL << 6)*/	/* save value */
 #define SU_FLAG_ZEROINVALID	(1UL << 6)	/* Invalid if "0" value */
 #define SU_FLAG_NAINVALID	(1UL << 7)	/* Invalid if "N/A" value */
 #define SU_CMD_OFFSET		(1UL << 8)	/* Add +1 to the OID index */
 
-#define SU_FLAG_SEMI_STATIC	(1UL << 9) /* Refresh this entry once in several walks
- * (for R/W values user can set on device, like descriptions or contacts) */
+#define SU_FLAG_SEMI_STATIC	(1UL << 9)	/* Refresh this entry once in several walks
+						 				 * (for R/W values user can set on device,
+						 				 * like descriptions or contacts) */
 
 /* Notes on outlet templates usage:
  * - outlet.count MUST exist and MUST be declared before any outlet template
@@ -298,18 +298,20 @@ typedef struct {
  * in the formatting string. This is useful when considering daisychain with
  * templates, such as outlets / outlets groups, which already have a format
  * string specifier */
-/* "flags" bits 21..23 */
+/* "flags" bits 21..23 (and 24 reserved for DMF) */
 #define SU_TYPE_DAISY_1		(1UL << 21)	/* Daisychain index is the 1st specifier */
 #define SU_TYPE_DAISY_2		(1UL << 22)	/* Daisychain index is the 2nd specifier */
 #define SU_TYPE_DAISY(t)	((t)->flags & (11UL << 21))	/* Mask the 3 SU_TYPE_DAISY_* but not SU_DAISY */
 #define SU_DAISY			(1UL << 23)	/* Daisychain template definition - set at run-time for devices with detected "device.count" over 1 */
 /* NOTE: Previously SU_DAISY had same bit-flag value as SU_TYPE_DAISY_2*/
-#define SU_TYPE_DAISY_MASTER_ONLY	(1UL << 24) /* Only valid for daisychain master (device.1) */
+#define SU_TYPE_DAISY_MASTER_ONLY	(1UL << 24)	/* Only valid for daisychain master (device.1) */
+
+/* Free slot: (1UL << 25) */
 
 #define SU_AMBIENT_TEMPLATE	(1UL << 26)	/* ambient template definition */
 
 #if WITH_DMF_FUNCTIONS
-#define SU_FLAG_FUNCTION	(1UL << 27)	/* TODO Pending to check if this flag have any incompatibility*/
+#define SU_FLAG_FUNCTION	(1UL << 27)	/* TODO Pending to check if this flag have any incompatibility */
 #endif
 
 /* status string components

--- a/drivers/snmp-ups.h
+++ b/drivers/snmp-ups.h
@@ -247,13 +247,16 @@ typedef struct {
 						 				 * provider of this info,
 						 				 * disable the other providers */
 /* Free slot (used by SU_AMBIENT_TEMPLATE in DMF branch)
+ * Note: older releases defined the following flag, but removed it by 2.7.5:
  * #define SU_FLAG_SETINT	(1UL << 6)*/	/* save value */
-#define SU_OUTLET			(1UL << 7)	/* outlet template definition */
+#define SU_FLAG_ZEROINVALID	(1UL << 6)	/* Invalid if "0" value */
+#define SU_FLAG_NAINVALID	(1UL << 7)	/* Invalid if "N/A" value */
 #define SU_CMD_OFFSET		(1UL << 8)	/* Add +1 to the OID index */
 
-#if WITH_DMF_FUNCTIONS
-#define SU_FLAG_FUNCTION	(1 << 9)	/* TODO Pending to check if this flag have any incompatibility*/
-#endif
+//#if WITH_DMF_FUNCTIONS
+//#define SU_FLAG_FUNCTION	(1 << 9)	/* TODO Pending to check if this flag have any incompatibility*/
+//#endif
+/* Reserved slot (1UL << 9) -- to import SU_FLAG_FUNCTION from DMF branch codebase */
 
 /* Notes on outlet templates usage:
  * - outlet.count MUST exist and MUST be declared before any outlet template
@@ -262,41 +265,29 @@ typedef struct {
  *   a valid OID) in order to detect the base SNMP index (0 or 1)
  */
 
-/* status string components
- * FIXME: these should be removed, since there is no added value.
- * Ie, this can be guessed from info->type! */
-
-/* "flags" value 0, or bits 8..9, or "8 and 9" */
-#define SU_STATUS_PWR		(0UL << 8)	/* indicates power status element */
-#define SU_STATUS_BATT		(1UL << 8)	/* indicates battery status element */
-#define SU_STATUS_CAL		(2UL << 8)	/* indicates calibration status element */
-#define SU_STATUS_RB		(3UL << 8)	/* indicates replace battery status element */
-#define SU_STATUS_NUM_ELEM	4			/* Obsolete? No references found in codebase */
-#define SU_STATUS_INDEX(t)	(((unsigned long)(t) >> 8) & 7UL)
-
 /* "flags" bit 10 */
 #define SU_OUTLET_GROUP		(1UL << 10)	/* outlet group template definition */
+#define SU_OUTLET			(1UL << 11)	/* outlet template definition */
 
 /* Phase specific data */
 /* "flags" bits 12..17 */
-#define SU_PHASES		(0x0000003F << 12)
-#define SU_INPHASES		(0x00000003 << 12)
-#define SU_INPUT_1		(1UL << 12)	/* only if 1 input phase */
-#define SU_INPUT_3		(1UL << 13)	/* only if 3 input phases */
-#define SU_OUTPHASES	(0x00000003 << 14)
-#define SU_OUTPUT_1		(1UL << 14)	/* only if 1 output phase */
-#define SU_OUTPUT_3		(1UL << 15)	/* only if 3 output phases */
-#define SU_BYPPHASES	(0x00000003 << 16)
-#define SU_BYPASS_1		(1UL << 16)	/* only if 1 bypass phase */
-#define SU_BYPASS_3		(1UL << 17)	/* only if 3 bypass phases */
+#define SU_PHASES			(0x0000003F << 12)
+#define SU_INPHASES			(0x00000003 << 12)
+#define SU_INPUT_1			(1UL << 12)	/* only if 1 input phase */
+#define SU_INPUT_3			(1UL << 13)	/* only if 3 input phases */
+#define SU_OUTPHASES		(0x00000003 << 14)
+#define SU_OUTPUT_1			(1UL << 14)	/* only if 1 output phase */
+#define SU_OUTPUT_3			(1UL << 15)	/* only if 3 output phases */
+#define SU_BYPPHASES		(0x00000003 << 16)
+#define SU_BYPASS_1			(1UL << 16)	/* only if 1 bypass phase */
+#define SU_BYPASS_3			(1UL << 17)	/* only if 3 bypass phases */
 /* FIXME: use input.phases and output.phases to replace this */
 
 /* hints for su_ups_set, applicable only to rw vars */
-/* "flags" value 0, or bits 18..19, or "18 and 19" */
-#define SU_TYPE_INT			(0UL << 18)	/* cast to int when setting value */
-/* Free slot                (1UL << 18) */
-#define SU_TYPE_TIME		(2UL << 18)	/* cast to int */
-#define SU_TYPE_CMD			(3UL << 18)	/* instant command */
+/* "flags" bits 18..20 */
+#define SU_TYPE_INT			(1UL << 18)	/* cast to int when setting value */
+#define SU_TYPE_TIME		(1UL << 19)	/* cast to int */
+#define SU_TYPE_CMD			(1UL << 20)	/* instant command */
 /* The following helper macro is used like:
  *   if (SU_TYPE(su_info_p) == SU_TYPE_CMD) { ... }
  */
@@ -307,22 +298,32 @@ typedef struct {
  * in the formatting string. This is useful when considering daisychain with
  * templates, such as outlets / outlets groups, which already have a format
  * string specifier */
-/* "flags" bits 19..20, and 20 again */
-#define SU_TYPE_DAISY_1		(1UL << 19)	/* Daisychain index is the 1st specifier */
-#define SU_TYPE_DAISY_2		(2UL << 19)	/* Daisychain index is the 2nd specifier */
-#define SU_TYPE_DAISY(t)	((t)->flags & (7UL << 19))
-#define SU_DAISY			(2UL << 19)	/* Daisychain template definition */
-
-/* "flags" bits 20..21 */
-#define SU_FLAG_ZEROINVALID	(1UL << 20)	/* Invalid if "0" value */
-#define SU_FLAG_NAINVALID	(1UL << 21)	/* Invalid if "N/A" value */
+/* "flags" bits 21..23 */
+#define SU_TYPE_DAISY_1		(1UL << 21)	/* Daisychain index is the 1st specifier */
+#define SU_TYPE_DAISY_2		(1UL << 22)	/* Daisychain index is the 2nd specifier */
+#define SU_TYPE_DAISY(t)	((t)->flags & (7UL << 21))	/* FIXME? Mask with 7 or 3 here? */
+#define SU_DAISY			(1UL << 23)	/* Daisychain template definition */
+/* NOTE: Previously SU_DAISY had same bit-flag value as SU_TYPE_DAISY_2*/
 
 /* Definitions from DMF branch, 42ITy fork */
-#define SU_AMBIENT_TEMPLATE	(1 << 6)	/* ambient template definition */
-#define SU_FLAG_SEMI_STATIC	(1 << 22) /* Refresh this entry once in several walks
- * (for R/W values user can set on device, like descriptions or contacts) */
-#define SU_TYPE_DAISY_MASTER_ONLY	(1 << 23) /* Only valid for daisychain master (device.1) */
+//#define SU_AMBIENT_TEMPLATE	(1 << 6)	/* ambient template definition */
+//#define SU_FLAG_SEMI_STATIC	(1 << 22) /* Refresh this entry once in several walks
+// * (for R/W values user can set on device, like descriptions or contacts) */
+//#define SU_TYPE_DAISY_MASTER_ONLY	(1 << 23) /* Only valid for daisychain master (device.1) */
 
+/* status string components
+ * FIXME: these should be removed, since there is no added value.
+ * Ie, this can be guessed from info->type! */
+
+/* "flags" bits 24..27 */
+#define SU_STATUS_PWR		(1UL << 24)	/* indicates power status element */
+#define SU_STATUS_BATT		(1UL << 25)	/* indicates battery status element */
+#define SU_STATUS_CAL		(1UL << 26)	/* indicates calibration status element */
+#define SU_STATUS_RB		(1UL << 27)	/* indicates replace battery status element */
+#define SU_STATUS_NUM_ELEM	4			/* Obsolete? No references found in codebase */
+#define SU_STATUS_INDEX(t)	(((unsigned long)(t) >> 24) & 15UL)
+
+/* Despite similar names, definitons below are not among the bit-flags ;) */
 #define SU_VAR_COMMUNITY	"community"
 #define SU_VAR_VERSION		"snmp_version"
 #define SU_VAR_RETRIES		"snmp_retries"

--- a/scripts/DMF/dmfsnmp.xsd
+++ b/scripts/DMF/dmfsnmp.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <xs:schema
- version="1.1.0"
+ version="1.2.0"
  attributeFormDefault="unqualified" elementFormDefault="qualified"
  xmlns:xs="http://www.w3.org/2001/XMLSchema"
  targetNamespace="http://www.networkupstools.org/dmf/snmp/snmp-ups"
@@ -115,7 +115,10 @@
                       <xs:attribute type="xs:string" name="lookup" use="optional"/>
                       <!-- Note: setvar was obsoleted and will be ignored by codebase -->
                       <xs:attribute type="xs:string" name="setvar" use="optional"/>
+                      <xs:attribute type="xs:string" name="int_val" use="optional"/>
+                      <xs:attribute type="xs:string" name="time_val" use="optional"/>
                       <xs:attribute type="xs:string" name="command" use="optional"/>
+                      <xs:attribute type="xs:string" name="command_offset" use="optional"/>
                       <xs:attribute type="xs:string" name="type_daisy" use="optional"/>
                       <xs:attribute type="xs:string" name="zero_invalid" use="optional"/>
                       <xs:attribute type="xs:string" name="na_invalid" use="optional"/>

--- a/scripts/DMF/dmfsnmp/apc-mib.dmf
+++ b/scripts/DMF/dmfsnmp/apc-mib.dmf
@@ -88,10 +88,10 @@
 		<snmp_info default="" flag_ok="yes" multiplier="0.1" name="input.frequency" oid=".1.3.6.1.4.1.318.1.1.1.9.2.2.1.4.1" positive="yes" unique="yes"/>
 		<snmp_info default="" flag_ok="yes" multiplier="0.1" name="input.frequency" oid=".1.3.6.1.4.1.318.1.1.1.3.3.4.0" positive="yes" unique="yes"/>
 		<snmp_info default="" flag_ok="yes" multiplier="1.0" name="input.frequency" oid=".1.3.6.1.4.1.318.1.1.1.3.2.4.0"/>
-		<snmp_info default="" flag_ok="yes" multiplier="3.0" name="input.transfer.low" oid=".1.3.6.1.4.1.318.1.1.1.5.2.3.0" power_status="yes" string="yes" writable="yes"/>
-		<snmp_info default="" flag_ok="yes" multiplier="3.0" name="input.transfer.high" oid=".1.3.6.1.4.1.318.1.1.1.5.2.2.0" power_status="yes" string="yes" writable="yes"/>
-		<snmp_info default="" flag_ok="yes" lookup="apcc_transfer_reasons" multiplier="1.0" name="input.transfer.reason" oid="1.3.6.1.4.1.318.1.1.1.3.2.5.0" power_status="yes" string="yes"/>
-		<snmp_info default="" flag_ok="yes" lookup="apcc_sensitivity_modes" multiplier="1.0" name="input.sensitivity" oid=".1.3.6.1.4.1.318.1.1.1.5.2.7.0" power_status="yes" string="yes" writable="yes"/>
+		<snmp_info default="" flag_ok="yes" int_val="yes" multiplier="3.0" name="input.transfer.low" oid=".1.3.6.1.4.1.318.1.1.1.5.2.3.0" string="yes" writable="yes"/>
+		<snmp_info default="" flag_ok="yes" int_val="yes" multiplier="3.0" name="input.transfer.high" oid=".1.3.6.1.4.1.318.1.1.1.5.2.2.0" string="yes" writable="yes"/>
+		<snmp_info default="" flag_ok="yes" int_val="yes" lookup="apcc_transfer_reasons" multiplier="1.0" name="input.transfer.reason" oid="1.3.6.1.4.1.318.1.1.1.3.2.5.0" string="yes"/>
+		<snmp_info default="" flag_ok="yes" int_val="yes" lookup="apcc_sensitivity_modes" multiplier="1.0" name="input.sensitivity" oid=".1.3.6.1.4.1.318.1.1.1.5.2.7.0" string="yes" writable="yes"/>
 		<snmp_info default="" flag_ok="yes" multiplier="1.0" name="ups.power" oid=".1.3.6.1.4.1.318.1.1.1.4.2.9.0"/>
 		<snmp_info default="" flag_ok="yes" multiplier="1.0" name="ups.realpower" oid=".1.3.6.1.4.1.318.1.1.1.4.2.8.0"/>
 		<snmp_info default="OFF" flag_ok="yes" lookup="apcc_pwr_info" multiplier="128.0" name="ups.status" oid=".1.3.6.1.4.1.318.1.1.1.4.1.1.0" power_status="yes" string="yes"/>
@@ -103,11 +103,11 @@
 		<snmp_info default="" flag_ok="yes" multiplier="0.1" name="ups.load" oid=".1.3.6.1.4.1.318.1.1.1.4.3.3.0" positive="yes" unique="yes"/>
 		<snmp_info default="" flag_ok="yes" multiplier="1.0" name="ups.load" oid=".1.3.6.1.4.1.318.1.1.1.4.2.3.0"/>
 		<snmp_info default="" flag_ok="yes" multiplier="16.0" name="ups.firmware" oid=".1.3.6.1.4.1.318.1.1.1.1.2.1.0" static="yes" string="yes"/>
-		<snmp_info default="" flag_ok="yes" multiplier="3.0" name="ups.delay.shutdown" oid=".1.3.6.1.4.1.318.1.1.1.5.2.10.0" type_daisy="1" writable="yes"/>
-		<snmp_info default="" flag_ok="yes" multiplier="3.0" name="ups.delay.start" oid=".1.3.6.1.4.1.318.1.1.1.5.2.9.0" type_daisy="1" writable="yes"/>
+		<snmp_info default="" flag_ok="yes" multiplier="3.0" name="ups.delay.shutdown" oid=".1.3.6.1.4.1.318.1.1.1.5.2.10.0" time_val="yes" writable="yes"/>
+		<snmp_info default="" flag_ok="yes" multiplier="3.0" name="ups.delay.start" oid=".1.3.6.1.4.1.318.1.1.1.5.2.9.0" time_val="yes" writable="yes"/>
 		<snmp_info default="" flag_ok="yes" multiplier="0.1" name="battery.charge" oid=".1.3.6.1.4.1.318.1.1.1.2.3.1.0" positive="yes" unique="yes"/>
 		<snmp_info default="" flag_ok="yes" multiplier="1.0" name="battery.charge" oid=".1.3.6.1.4.1.318.1.1.1.2.2.1.0"/>
-		<snmp_info default="" flag_ok="yes" multiplier="3.0" name="battery.charge.restart" oid=".1.3.6.1.4.1.318.1.1.1.5.2.6.0" power_status="yes" string="yes" writable="yes"/>
+		<snmp_info default="" flag_ok="yes" int_val="yes" multiplier="3.0" name="battery.charge.restart" oid=".1.3.6.1.4.1.318.1.1.1.5.2.6.0" string="yes" writable="yes"/>
 		<snmp_info default="" flag_ok="yes" multiplier="1.0" name="battery.runtime" oid=".1.3.6.1.4.1.318.1.1.1.2.2.3.0"/>
 		<snmp_info default="" flag_ok="yes" multiplier="3.0" name="battery.runtime.low" oid=".1.3.6.1.4.1.318.1.1.1.5.2.8.0" string="yes" writable="yes"/>
 		<snmp_info default="" flag_ok="yes" multiplier="0.1" name="battery.voltage" oid=".1.3.6.1.4.1.318.1.1.1.2.3.4.0" positive="yes" unique="yes"/>
@@ -160,7 +160,7 @@
 		<snmp_info default="" flag_ok="yes" multiplier="1.0" name="output.L1.power.minimum.percent" oid=".1.3.6.1.4.1.318.1.1.1.9.3.3.1.12.1.1.1" positive="yes"/>
 		<snmp_info default="" flag_ok="yes" multiplier="1.0" name="output.L2.power.minimum.percent" oid=".1.3.6.1.4.1.318.1.1.1.9.3.3.1.12.1.1.2" positive="yes"/>
 		<snmp_info default="" flag_ok="yes" multiplier="1.0" name="output.L3.power.minimum.percent" oid=".1.3.6.1.4.1.318.1.1.1.9.3.3.1.12.1.1.3" positive="yes"/>
-		<snmp_info default="" flag_ok="yes" multiplier="3.0" name="output.voltage.nominal" oid=".1.3.6.1.4.1.318.1.1.1.5.2.1.0" power_status="yes" string="yes" writable="yes"/>
+		<snmp_info default="" flag_ok="yes" int_val="yes" multiplier="3.0" name="output.voltage.nominal" oid=".1.3.6.1.4.1.318.1.1.1.5.2.1.0" string="yes" writable="yes"/>
 		<snmp_info default="" flag_ok="yes" multiplier="1.0" name="ambient.temperature" oid=".1.3.6.1.4.1.318.1.1.2.1.1.0"/>
 		<snmp_info default="" flag_ok="yes" multiplier="1.0" name="ambient.1.temperature.alarm.high" oid=".1.3.6.1.4.1.318.1.1.10.1.2.2.1.3.1"/>
 		<snmp_info default="" flag_ok="yes" multiplier="1.0" name="ambient.1.temperature.alarm.low" oid=".1.3.6.1.4.1.318.1.1.10.1.2.2.1.4.1"/>

--- a/scripts/DMF/dmfsnmp/baytech-mib.dmf
+++ b/scripts/DMF/dmfsnmp/baytech-mib.dmf
@@ -21,12 +21,12 @@
 		<snmp_info default="" flag_ok="yes" multiplier="128.0" name="ups.serial" oid=".1.3.6.1.4.1.4779.1.1.2.0" static="yes" string="yes"/>
 		<snmp_info default="" flag_ok="yes" multiplier="128.0" name="ups.firmware" oid=".1.3.6.1.4.1.4779.1.1.1.0" static="yes" string="yes"/>
 		<snmp_info absent="yes" default="pdu" flag_ok="yes" multiplier="128.0" name="ups.type" static="yes" string="yes"/>
-		<snmp_info multiplier="0.1" name="ups.temperature" oid=".1.3.6.1.4.1.4779.1.3.5.5.1.10.2.1" power_status="yes"/>
+		<snmp_info multiplier="0.1" name="ups.temperature" oid=".1.3.6.1.4.1.4779.1.3.5.5.1.10.2.1"/>
 		<snmp_info absent="yes" default="0" flag_ok="yes" multiplier="1.0" name="outlet.id" static="yes"/>
 		<snmp_info absent="yes" default="All outlets" flag_ok="yes" multiplier="20.0" name="outlet.desc" static="yes" string="yes" writable="yes"/>
-		<snmp_info default="0" multiplier="1.0" name="outlet.count" oid=".1.3.6.1.4.1.4779.1.3.5.2.1.15.1" power_status="yes"/>
-		<snmp_info multiplier="0.1" name="outlet.current" oid=".1.3.6.1.4.1.4779.1.3.5.5.1.6.2.1" power_status="yes"/>
-		<snmp_info multiplier="0.1" name="outlet.voltage" oid=".1.3.6.1.4.1.4779.1.3.5.5.1.8.2.1" power_status="yes"/>
+		<snmp_info default="0" multiplier="1.0" name="outlet.count" oid=".1.3.6.1.4.1.4779.1.3.5.2.1.15.1"/>
+		<snmp_info multiplier="0.1" name="outlet.current" oid=".1.3.6.1.4.1.4779.1.3.5.5.1.6.2.1"/>
+		<snmp_info multiplier="0.1" name="outlet.voltage" oid=".1.3.6.1.4.1.4779.1.3.5.5.1.8.2.1"/>
 		<snmp_info lookup="baytech_outlet_status_info" multiplier="128.0" name="outlet.%i.status" oid=".1.3.6.1.4.1.4779.1.3.5.3.1.3.1.%i" outlet="yes" string="yes"/>
 		<snmp_info multiplier="128.0" name="outlet.%i.desc" oid=".1.3.6.1.4.1.4779.1.3.5.3.1.4.1.%i" outlet="yes" string="yes" writable="yes"/>
 		<snmp_info absent="yes" default="%i" flag_ok="yes" multiplier="1.0" name="outlet.%i.id" oid=".1.3.6.1.4.1.4779.1.3.5.6.1.3.2.1.%i" outlet="yes" static="yes"/>

--- a/scripts/DMF/dmfsnmp/bestpower-mib.dmf
+++ b/scripts/DMF/dmfsnmp/bestpower-mib.dmf
@@ -13,13 +13,13 @@
 		<snmp_info default="Best Ferrups" multiplier="128.0" name="ups.model" oid=".1.3.6.1.4.1.2947.1.1.2.0" static="yes" string="yes"/>
 		<snmp_info default="" multiplier="128.0" name="ups.serial" oid=".1.3.6.1.4.1.2947.1.1.5.0" static="yes" string="yes"/>
 		<snmp_info default="" multiplier="128.0" name="ups.firmware" oid=".1.3.6.1.4.1.2947.1.1.7.0" static="yes" string="yes"/>
-		<snmp_info default="" multiplier="1.0" name="ups.power" oid=".1.3.6.1.4.1.2947.1.1.3.0" power_status="yes"/>
-		<snmp_info default="" multiplier="128.0" name="ups.mfr.date" oid=".1.3.6.1.4.1.2947.1.1.8.0" power_status="yes" string="yes"/>
-		<snmp_info default="" lookup="bestpower_power_status" multiplier="128.0" name="ups.status" oid=".1.3.6.1.4.1.2947.1.2.1.0" power_status="yes" string="yes"/>
-		<snmp_info default="" multiplier="60.0" name="battery.runtime" oid=".1.3.6.1.4.1.2947.1.2.3.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="battery.runtime.elapsed" oid=".1.3.6.1.4.1.2947.1.2.2.0" power_status="yes"/>
-		<snmp_info default="" multiplier="0.1" name="battery.voltage" oid=".1.3.6.1.4.1.2947.1.2.4.0" power_status="yes"/>
-		<snmp_info default="" multiplier="0.1" name="battery.current" oid=".1.3.6.1.4.1.2947.1.2.5.0" power_status="yes"/>
+		<snmp_info default="" multiplier="1.0" name="ups.power" oid=".1.3.6.1.4.1.2947.1.1.3.0"/>
+		<snmp_info default="" multiplier="128.0" name="ups.mfr.date" oid=".1.3.6.1.4.1.2947.1.1.8.0" string="yes"/>
+		<snmp_info default="" lookup="bestpower_power_status" multiplier="128.0" name="ups.status" oid=".1.3.6.1.4.1.2947.1.2.1.0" string="yes"/>
+		<snmp_info default="" multiplier="60.0" name="battery.runtime" oid=".1.3.6.1.4.1.2947.1.2.3.0"/>
+		<snmp_info default="" multiplier="1.0" name="battery.runtime.elapsed" oid=".1.3.6.1.4.1.2947.1.2.2.0"/>
+		<snmp_info default="" multiplier="0.1" name="battery.voltage" oid=".1.3.6.1.4.1.2947.1.2.4.0"/>
+		<snmp_info default="" multiplier="0.1" name="battery.current" oid=".1.3.6.1.4.1.2947.1.2.5.0"/>
 	</snmp>
 	<mib2nut auto_check=".1.3.6.1.4.1.2947.1.1.2.0" mib_name="bestpower" name="bestpower" oid=".1.3.6.1.4.1.2947.1.1.2.0" snmp_info="bestpower_mib" version="0.2"/>
 </nut>

--- a/scripts/DMF/dmfsnmp/compaq-mib.dmf
+++ b/scripts/DMF/dmfsnmp/compaq-mib.dmf
@@ -57,9 +57,9 @@
 		<snmp_info default="HP/Compaq" multiplier="128.0" name="ups.mfr" oid=".1.3.6.1.4.1.232.165.3.1.1.0" static="yes" string="yes"/>
 		<snmp_info default="SNMP UPS" multiplier="128.0" name="ups.model" oid=".1.3.6.1.4.1.232.165.3.1.2.0" static="yes" string="yes"/>
 		<snmp_info default="" flag_ok="yes" multiplier="128.0" name="ups.serial" oid=".1.3.6.1.4.1.232.165.1.2.7.0" static="yes" string="yes"/>
-		<snmp_info default="" multiplier="128.0" name="ups.firmware" oid=".1.3.6.1.4.1.232.165.3.1.3.0" power_status="yes" string="yes"/>
-		<snmp_info default="" multiplier="128.0" name="ups.firmware.aux" oid=".1.3.6.1.2.1.33.1.1.4.0" power_status="yes" string="yes"/>
-		<snmp_info default="" multiplier="1.0" name="ups.load" oid=".1.3.6.1.4.1.232.165.3.4.1.0" power_status="yes"/>
+		<snmp_info default="" multiplier="128.0" name="ups.firmware" oid=".1.3.6.1.4.1.232.165.3.1.3.0" string="yes"/>
+		<snmp_info default="" multiplier="128.0" name="ups.firmware.aux" oid=".1.3.6.1.2.1.33.1.1.4.0" string="yes"/>
+		<snmp_info default="" multiplier="1.0" name="ups.load" oid=".1.3.6.1.4.1.232.165.3.4.1.0"/>
 		<snmp_info default="" multiplier="1.0" name="ups.realpower" oid=".1.3.6.1.4.1.232.165.3.4.4.1.4" output_1_phase="yes"/>
 		<snmp_info default="" multiplier="1.0" name="ups.realpower" oid=".1.3.6.1.4.1.232.165.3.9.3.0" output_1_phase="yes"/>
 		<snmp_info default="" multiplier="0.1" name="ups.L1.realpower" oid=".1.3.6.1.4.1.232.165.3.4.4.1.4.1" output_3_phase="yes"/>
@@ -68,20 +68,20 @@
 		<snmp_info default="OFF" lookup="cpqpower_pwr_info" multiplier="128.0" name="ups.status" oid=".1.3.6.1.4.1.232.165.3.4.5.0" power_status="yes" string="yes"/>
 		<snmp_info default="" lookup="cpqpower_battery_abm_status" multiplier="128.0" name="ups.status" oid=".1.3.6.1.4.1.232.165.3.2.5.0" power_status="yes" string="yes"/>
 		<snmp_info default="" lookup="cpqpower_mode_info" multiplier="128.0" name="ups.type" oid=".1.3.6.1.4.1.232.165.3.4.5.0" power_status="yes" string="yes"/>
-		<snmp_info default="" lookup="cpqpower_test_res_info" multiplier="128.0" name="ups.test.result" oid=".1.3.6.1.4.1.232.165.3.7.2.0" power_status="yes" string="yes"/>
+		<snmp_info default="" lookup="cpqpower_test_res_info" multiplier="128.0" name="ups.test.result" oid=".1.3.6.1.4.1.232.165.3.7.2.0" string="yes"/>
 		<snmp_info absent="yes" default="20" flag_ok="yes" multiplier="6.0" name="ups.delay.shutdown" oid=".1.3.6.1.4.1.232.165.3.8.1.0" string="yes" writable="yes"/>
 		<snmp_info absent="yes" default="30" flag_ok="yes" multiplier="6.0" name="ups.delay.start" oid=".1.3.6.1.4.1.232.165.3.8.2.0" string="yes" writable="yes"/>
 		<snmp_info default="" flag_ok="yes" multiplier="1.0" name="ups.timer.shutdown" oid=".1.3.6.1.4.1.232.165.3.8.1.0"/>
 		<snmp_info default="" flag_ok="yes" multiplier="1.0" name="ups.timer.start" oid=".1.3.6.1.4.1.232.165.3.8.2.0"/>
-		<snmp_info default="" multiplier="1.0" name="ambient.temperature" oid=".1.3.6.1.4.1.232.165.3.6.1.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="ambient.temperature.low" oid=".1.3.6.1.4.1.232.165.3.6.2.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="ambient.temperature.high" oid=".1.3.6.1.4.1.232.165.3.6.3.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="battery.charge" oid=".1.3.6.1.4.1.232.165.3.2.4.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="battery.runtime" oid=".1.3.6.1.4.1.232.165.3.2.1.0" power_status="yes"/>
-		<snmp_info default="" multiplier="0.1" name="battery.voltage" oid=".1.3.6.1.4.1.232.165.3.2.2.0" power_status="yes"/>
-		<snmp_info default="" multiplier="0.1" name="battery.current" oid=".1.3.6.1.4.1.232.165.3.2.3.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="input.phases" oid=".1.3.6.1.4.1.232.165.3.3.3.0" power_status="yes"/>
-		<snmp_info default="" multiplier="0.1" name="input.frequency" oid=".1.3.6.1.4.1.232.165.3.3.1.0" power_status="yes"/>
+		<snmp_info default="" multiplier="1.0" name="ambient.temperature" oid=".1.3.6.1.4.1.232.165.3.6.1.0"/>
+		<snmp_info default="" multiplier="1.0" name="ambient.temperature.low" oid=".1.3.6.1.4.1.232.165.3.6.2.0"/>
+		<snmp_info default="" multiplier="1.0" name="ambient.temperature.high" oid=".1.3.6.1.4.1.232.165.3.6.3.0"/>
+		<snmp_info default="" multiplier="1.0" name="battery.charge" oid=".1.3.6.1.4.1.232.165.3.2.4.0"/>
+		<snmp_info default="" multiplier="1.0" name="battery.runtime" oid=".1.3.6.1.4.1.232.165.3.2.1.0"/>
+		<snmp_info default="" multiplier="0.1" name="battery.voltage" oid=".1.3.6.1.4.1.232.165.3.2.2.0"/>
+		<snmp_info default="" multiplier="0.1" name="battery.current" oid=".1.3.6.1.4.1.232.165.3.2.3.0"/>
+		<snmp_info default="" multiplier="1.0" name="input.phases" oid=".1.3.6.1.4.1.232.165.3.3.3.0"/>
+		<snmp_info default="" multiplier="0.1" name="input.frequency" oid=".1.3.6.1.4.1.232.165.3.3.1.0"/>
 		<snmp_info default="" multiplier="1.0" name="input.voltage" oid=".1.3.6.1.4.1.232.165.3.3.4.1.2" output_1_phase="yes"/>
 		<snmp_info default="" multiplier="1.0" name="input.voltage" oid=".1.3.6.1.4.1.232.165.3.3.4.1.2.1" output_1_phase="yes"/>
 		<snmp_info default="" multiplier="3.0" name="input.voltage.nominal" oid=".1.3.6.1.4.1.232.165.3.9.2.0" output_1_phase="yes" string="yes" writable="yes"/>
@@ -97,9 +97,9 @@
 		<snmp_info default="" input_3_phase="yes" multiplier="0.1" name="input.L1.realpower" oid=".1.3.6.1.4.1.232.165.3.3.4.1.4.1"/>
 		<snmp_info default="" input_3_phase="yes" multiplier="0.1" name="input.L2.realpower" oid=".1.3.6.1.4.1.232.165.3.3.4.1.4.2"/>
 		<snmp_info default="" input_3_phase="yes" multiplier="0.1" name="input.L3.realpower" oid=".1.3.6.1.4.1.232.165.3.3.4.1.4.3"/>
-		<snmp_info default="" multiplier="1.0" name="input.quality" oid=".1.3.6.1.4.1.232.165.3.3.2.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="output.phases" oid=".1.3.6.1.4.1.232.165.3.4.3.0" power_status="yes"/>
-		<snmp_info default="" multiplier="0.1" name="output.frequency" oid=".1.3.6.1.4.1.232.165.3.4.2.0" power_status="yes"/>
+		<snmp_info default="" multiplier="1.0" name="input.quality" oid=".1.3.6.1.4.1.232.165.3.3.2.0"/>
+		<snmp_info default="" multiplier="1.0" name="output.phases" oid=".1.3.6.1.4.1.232.165.3.4.3.0"/>
+		<snmp_info default="" multiplier="0.1" name="output.frequency" oid=".1.3.6.1.4.1.232.165.3.4.2.0"/>
 		<snmp_info default="" multiplier="3.0" name="output.frequency.nominal" oid=".1.3.6.1.4.1.232.165.3.9.4.0" output_1_phase="yes" string="yes" writable="yes"/>
 		<snmp_info default="" multiplier="1.0" name="output.voltage" oid=".1.3.6.1.4.1.232.165.3.4.4.1.2" output_1_phase="yes"/>
 		<snmp_info default="" multiplier="1.0" name="output.voltage" oid=".1.3.6.1.4.1.232.165.3.4.4.1.2.1" output_1_phase="yes"/>
@@ -114,7 +114,7 @@
 		<snmp_info default="" multiplier="0.1" name="output.L3.current" oid=".1.3.6.1.4.1.232.165.3.4.4.1.3.3" output_3_phase="yes"/>
 		<snmp_info absent="yes" default="0" flag_ok="yes" multiplier="1.0" name="outlet.id" static="yes"/>
 		<snmp_info absent="yes" default="All outlets" flag_ok="yes" multiplier="20.0" name="outlet.desc" static="yes" string="yes" writable="yes"/>
-		<snmp_info default="0" multiplier="1.0" name="outlet.count" oid=".1.3.6.1.4.1.232.165.3.10.1.0" power_status="yes"/>
+		<snmp_info default="0" multiplier="1.0" name="outlet.count" oid=".1.3.6.1.4.1.232.165.3.10.1.0"/>
 		<snmp_info default="yes" lookup="cpqpower_outlet_switchability_info" multiplier="3.0" name="outlet.%i.switchable" oid=".1.3.6.1.4.1.232.165.3.10.2.1.1.%i" outlet="yes" static="yes" string="yes"/>
 		<snmp_info absent="yes" default="%i" flag_ok="yes" multiplier="1.0" name="outlet.%i.id" oid=".1.3.6.1.4.1.232.165.3.10.2.1.1.%i" outlet="yes" static="yes"/>
 		<snmp_info flag_ok="yes" lookup="cpqpower_outlet_status_info" multiplier="128.0" name="outlet.%i.status" oid=".1.3.6.1.4.1.232.165.3.10.2.1.2.%i" outlet="yes" string="yes"/>

--- a/scripts/DMF/dmfsnmp/cyberpower-mib.dmf
+++ b/scripts/DMF/dmfsnmp/cyberpower-mib.dmf
@@ -32,29 +32,29 @@
 		<snmp_info default="CyberPower" multiplier="128.0" name="ups.model" oid=".1.3.6.1.4.1.3808.1.1.1.1.1.1.0" static="yes" string="yes"/>
 		<snmp_info default="" multiplier="128.0" name="ups.serial" oid=".1.3.6.1.4.1.3808.1.1.1.1.2.3.0" static="yes" string="yes"/>
 		<snmp_info default="" multiplier="128.0" name="ups.firmware" oid=".1.3.6.1.4.1.3808.1.1.1.1.2.1.0" static="yes" string="yes"/>
-		<snmp_info default="" multiplier="128.0" name="ups.mfr.date" oid=".1.3.6.1.4.1.3808.1.1.1.1.2.2.0" power_status="yes" string="yes"/>
+		<snmp_info default="" multiplier="128.0" name="ups.mfr.date" oid=".1.3.6.1.4.1.3808.1.1.1.1.2.2.0" string="yes"/>
 		<snmp_info default="" flag_ok="yes" lookup="cyberpower_power_status" multiplier="128.0" name="ups.status" oid=".1.3.6.1.4.1.3808.1.1.1.4.1.1.0" power_status="yes" string="yes"/>
 		<snmp_info battery_status="yes" default="" flag_ok="yes" lookup="cyberpower_battery_status" multiplier="128.0" name="ups.status" oid=".1.3.6.1.4.1.3808.1.1.1.2.1.1.0" string="yes"/>
 		<snmp_info calibration="yes" default="" flag_ok="yes" lookup="cyberpower_cal_status" multiplier="128.0" name="ups.status" oid=".1.3.6.1.4.1.3808.1.1.1.7.2.7.0" string="yes"/>
 		<snmp_info default="" flag_ok="yes" lookup="cyberpower_battrepl_status" multiplier="128.0" name="ups.status" oid=".1.3.6.1.4.1.3808.1.1.1.2.2.5.0" replace_battery="yes" string="yes"/>
-		<snmp_info default="" multiplier="1.0" name="ups.load" oid=".1.3.6.1.4.1.3808.1.1.1.4.2.3.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="battery.runtime" oid=".1.3.6.1.4.1.3808.1.1.1.2.2.4.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="battery.runtime.elapsed" oid=".1.3.6.1.4.1.3808.1.1.1.2.1.2.0" power_status="yes"/>
-		<snmp_info default="" multiplier="0.1" name="battery.voltage" oid=".1.3.6.1.2.1.33.1.2.5.0" power_status="yes"/>
-		<snmp_info default="" multiplier="0.1" name="battery.voltage" oid=".1.3.6.1.4.1.3808.1.1.1.2.2.2.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="battery.voltage.nominal" oid=".1.3.6.1.4.1.3808.1.1.1.2.2.8.0" power_status="yes"/>
-		<snmp_info default="" multiplier="0.1" name="battery.current" oid=".1.3.6.1.4.1.3808.1.1.1.4.2.4.0" power_status="yes"/>
-		<snmp_info default="" multiplier="0.1" name="battery.current" oid=".1.3.6.1.4.1.3808.1.1.1.2.2.7.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="battery.charge" oid=".1.3.6.1.4.1.3808.1.1.1.2.2.1.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="battery.temperature" oid=".1.3.6.1.4.1.3808.1.1.1.2.2.3.0" power_status="yes"/>
-		<snmp_info default="" multiplier="0.1" name="input.voltage" oid=".1.3.6.1.4.1.3808.1.1.1.3.2.1.0" power_status="yes"/>
-		<snmp_info default="" multiplier="0.1" name="input.frequency" oid=".1.3.6.1.4.1.3808.1.1.1.3.2.4.0" power_status="yes"/>
-		<snmp_info default="" multiplier="0.1" name="output.voltage" oid=".1.3.6.1.4.1.3808.1.1.1.4.2.1.0" power_status="yes"/>
-		<snmp_info default="" multiplier="0.1" name="output.frequency" oid=".1.3.6.1.4.1.3808.1.1.1.4.2.2.0" power_status="yes"/>
-		<snmp_info default="" multiplier="0.1" name="output.current" oid=".1.3.6.1.4.1.3808.1.1.1.4.2.4.0" power_status="yes"/>
-		<snmp_info default="0" flag_ok="yes" multiplier="1.0" name="ups.delay.start" oid=".1.3.6.1.4.1.3808.1.1.1.5.2.9.0" type_daisy="1" writable="yes"/>
+		<snmp_info default="" multiplier="1.0" name="ups.load" oid=".1.3.6.1.4.1.3808.1.1.1.4.2.3.0"/>
+		<snmp_info default="" multiplier="1.0" name="battery.runtime" oid=".1.3.6.1.4.1.3808.1.1.1.2.2.4.0"/>
+		<snmp_info default="" multiplier="1.0" name="battery.runtime.elapsed" oid=".1.3.6.1.4.1.3808.1.1.1.2.1.2.0"/>
+		<snmp_info default="" multiplier="0.1" name="battery.voltage" oid=".1.3.6.1.2.1.33.1.2.5.0"/>
+		<snmp_info default="" multiplier="0.1" name="battery.voltage" oid=".1.3.6.1.4.1.3808.1.1.1.2.2.2.0"/>
+		<snmp_info default="" multiplier="1.0" name="battery.voltage.nominal" oid=".1.3.6.1.4.1.3808.1.1.1.2.2.8.0"/>
+		<snmp_info default="" multiplier="0.1" name="battery.current" oid=".1.3.6.1.4.1.3808.1.1.1.4.2.4.0"/>
+		<snmp_info default="" multiplier="0.1" name="battery.current" oid=".1.3.6.1.4.1.3808.1.1.1.2.2.7.0"/>
+		<snmp_info default="" multiplier="1.0" name="battery.charge" oid=".1.3.6.1.4.1.3808.1.1.1.2.2.1.0"/>
+		<snmp_info default="" multiplier="1.0" name="battery.temperature" oid=".1.3.6.1.4.1.3808.1.1.1.2.2.3.0"/>
+		<snmp_info default="" multiplier="0.1" name="input.voltage" oid=".1.3.6.1.4.1.3808.1.1.1.3.2.1.0"/>
+		<snmp_info default="" multiplier="0.1" name="input.frequency" oid=".1.3.6.1.4.1.3808.1.1.1.3.2.4.0"/>
+		<snmp_info default="" multiplier="0.1" name="output.voltage" oid=".1.3.6.1.4.1.3808.1.1.1.4.2.1.0"/>
+		<snmp_info default="" multiplier="0.1" name="output.frequency" oid=".1.3.6.1.4.1.3808.1.1.1.4.2.2.0"/>
+		<snmp_info default="" multiplier="0.1" name="output.current" oid=".1.3.6.1.4.1.3808.1.1.1.4.2.4.0"/>
+		<snmp_info default="0" flag_ok="yes" multiplier="1.0" name="ups.delay.start" oid=".1.3.6.1.4.1.3808.1.1.1.5.2.9.0" time_val="yes" writable="yes"/>
 		<snmp_info absent="yes" default="0" flag_ok="yes" multiplier="1.0" name="ups.delay.reboot"/>
-		<snmp_info default="60" flag_ok="yes" multiplier="1.0" name="ups.delay.shutdown" oid=".1.3.6.1.4.1.3808.1.1.1.5.2.11.0" type_daisy="1" writable="yes"/>
+		<snmp_info default="60" flag_ok="yes" multiplier="1.0" name="ups.delay.shutdown" oid=".1.3.6.1.4.1.3808.1.1.1.5.2.11.0" time_val="yes" writable="yes"/>
 		<snmp_info command="yes" flag_ok="yes" multiplier="2.0" name="load.off" oid=".1.3.6.1.4.1.3808.1.1.1.6.2.1.0"/>
 		<snmp_info command="yes" flag_ok="yes" multiplier="2.0" name="load.on" oid=".1.3.6.1.4.1.3808.1.1.1.6.2.6.0"/>
 		<snmp_info command="yes" flag_ok="yes" multiplier="3.0" name="shutdown.stayoff" oid=".1.3.6.1.4.1.3808.1.1.1.6.2.6.0"/>

--- a/scripts/DMF/dmfsnmp/eaton-ats16-nm2-mib.dmf
+++ b/scripts/DMF/dmfsnmp/eaton-ats16-nm2-mib.dmf
@@ -111,7 +111,7 @@
 		<snmp_info flag_ok="yes" multiplier="1.0" name="ambient.humidity" oid=".1.3.6.1.4.1.534.10.2.5.2.0"/>
 		<snmp_info flag_ok="yes" multiplier="1.0" name="ambient.humidity.low" oid=".1.3.6.1.4.1.534.10.2.5.7.0" writable="yes"/>
 		<snmp_info flag_ok="yes" multiplier="1.0" name="ambient.humidity.high" oid=".1.3.6.1.4.1.534.10.2.5.8.0" writable="yes"/>
-		<snmp_info default="" multiplier="1.0" name="ambient.count" oid=".1.3.6.1.4.1.534.6.8.1.1.1.0" power_status="yes" writable="yes"/>
+		<snmp_info default="" multiplier="1.0" name="ambient.count" oid=".1.3.6.1.4.1.534.6.8.1.1.1.0" writable="yes"/>
 		<snmp_info ambient="yes" lookup="eaton_ats16_nm2_emp002_ambient_presence_info" multiplier="128.0" name="ambient.%i.present" oid=".1.3.6.1.4.1.534.6.8.1.1.4.1.1.%i" string="yes"/>
 		<snmp_info ambient="yes" default="" multiplier="1.0" name="ambient.%i.name" oid=".1.3.6.1.4.1.534.6.8.1.1.3.1.1.%i" string="yes"/>
 		<snmp_info ambient="yes" default="" multiplier="1.0" name="ambient.%i.mfr" oid=".1.3.6.1.4.1.534.6.8.1.1.2.1.6.%i" string="yes"/>

--- a/scripts/DMF/dmfsnmp/eaton-pdu-genesis2-mib.dmf
+++ b/scripts/DMF/dmfsnmp/eaton-pdu-genesis2-mib.dmf
@@ -7,7 +7,7 @@
 		<snmp_info absent="yes" default="EATON | Powerware" flag_ok="yes" multiplier="128.0" name="device.mfr" static="yes" string="yes"/>
 		<snmp_info default="Eaton Powerware ePDU Monitored" flag_ok="yes" multiplier="128.0" name="device.model" oid=".1.3.6.1.4.1.17373.3.1.1.0" static="yes" string="yes"/>
 		<snmp_info absent="yes" default="pdu" flag_ok="yes" multiplier="128.0" name="device.type" static="yes" string="yes"/>
-		<snmp_info default="unknown" multiplier="128.0" name="device.macaddr" oid=".1.3.6.1.4.1.17373.3.1.4.0" power_status="yes" string="yes"/>
+		<snmp_info default="unknown" multiplier="128.0" name="device.macaddr" oid=".1.3.6.1.4.1.17373.3.1.4.0" string="yes"/>
 		<snmp_info absent="yes" default="EATON | Powerware" flag_ok="yes" multiplier="128.0" name="ups.mfr" static="yes" string="yes"/>
 		<snmp_info default="Generic SNMP PDU" flag_ok="yes" multiplier="128.0" name="ups.model" oid=".1.3.6.1.4.1.17373.3.1.1.0" static="yes" string="yes"/>
 		<snmp_info default="unknown" flag_ok="yes" multiplier="128.0" name="ups.id" oid=".1.3.6.1.4.1.17373.3.1.3.0" static="yes" string="yes"/>

--- a/scripts/DMF/dmfsnmp/eaton-pdu-marlin-mib.dmf
+++ b/scripts/DMF/dmfsnmp/eaton-pdu-marlin-mib.dmf
@@ -158,67 +158,67 @@
 		<snmp_info default="" flag_ok="yes" multiplier="128.0" name="ups.firmware" oid=".1.3.6.1.4.1.534.6.6.7.1.2.1.5.%i" string="yes"/>
 		<snmp_info absent="yes" default="pdu" flag_ok="yes" multiplier="128.0" name="ups.type" static="yes" string="yes"/>
 		<snmp_info lookup="marlin_input_type_info" multiplier="1.0" name="input.phases" oid=".1.3.6.1.4.1.534.6.6.7.3.1.1.2.%i.1" static="yes"/>
-		<snmp_info multiplier="0.1" name="input.frequency" oid=".1.3.6.1.4.1.534.6.6.7.3.1.1.3.%i.1" power_status="yes"/>
+		<snmp_info multiplier="0.1" name="input.frequency" oid=".1.3.6.1.4.1.534.6.6.7.3.1.1.3.%i.1"/>
 		<snmp_info flag_ok="yes" lookup="marlin_threshold_frequency_status_info" multiplier="128.0" name="input.frequency.status" oid=".1.3.6.1.4.1.534.6.6.7.3.1.1.4.%i.1" string="yes"/>
 		<snmp_info flag_ok="yes" lookup="marlin_threshold_frequency_alarm_info" multiplier="128.0" name="ups.alarm" oid=".1.3.6.1.4.1.534.6.6.7.3.1.1.4.%i.1" string="yes"/>
 		<snmp_info flag_ok="yes" multiplier="1.0" name="input.load" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.11.%i.1.1" positive="yes"/>
 		<snmp_info flag_ok="yes" multiplier="1.0" name="input.L1.load" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.11.%i.1.1" positive="yes"/>
 		<snmp_info flag_ok="yes" multiplier="1.0" name="input.L2.load" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.11.%i.1.2" positive="yes"/>
 		<snmp_info flag_ok="yes" multiplier="1.0" name="input.L3.load" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.11.%i.1.3" positive="yes"/>
-		<snmp_info multiplier="0.001" name="input.voltage" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.3.%i.1.1" power_status="yes"/>
+		<snmp_info multiplier="0.001" name="input.voltage" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.3.%i.1.1"/>
 		<snmp_info flag_ok="yes" lookup="marlin_threshold_status_info" multiplier="128.0" name="input.voltage.status" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.4.%i.1.1" string="yes"/>
 		<snmp_info flag_ok="yes" lookup="marlin_threshold_voltage_alarms_info" multiplier="128.0" name="ups.alarm" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.4.%i.1.1" string="yes"/>
 		<snmp_info multiplier="0.001" name="input.voltage.low.warning" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.5.%i.1.1" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.voltage.low.critical" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.6.%i.1.1" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.voltage.high.warning" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.7.%i.1.1" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.voltage.high.critical" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.8.%i.1.1" positive="yes" writable="yes"/>
-		<snmp_info multiplier="0.001" name="input.L1.voltage" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.3.%i.1.1" power_status="yes"/>
+		<snmp_info multiplier="0.001" name="input.L1.voltage" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.3.%i.1.1"/>
 		<snmp_info flag_ok="yes" lookup="marlin_threshold_status_info" multiplier="128.0" name="input.L1.voltage.status" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.4.%i.1.1" string="yes"/>
 		<snmp_info flag_ok="yes" lookup="marlin_threshold_voltage_alarms_info" multiplier="128.0" name="L1.alarm" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.4.%i.1.1" string="yes"/>
 		<snmp_info multiplier="0.001" name="input.L1.voltage.low.warning" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.5.%i.1.1" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L1.voltage.low.critical" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.6.%i.1.1" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L1.voltage.high.warning" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.7.%i.1.1" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L1.voltage.high.critical" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.8.%i.1.1" positive="yes" writable="yes"/>
-		<snmp_info multiplier="0.001" name="input.L2.voltage" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.3.%i.1.2" power_status="yes"/>
+		<snmp_info multiplier="0.001" name="input.L2.voltage" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.3.%i.1.2"/>
 		<snmp_info flag_ok="yes" lookup="marlin_threshold_status_info" multiplier="128.0" name="input.L2.voltage.status" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.4.%i.1.2" string="yes"/>
 		<snmp_info flag_ok="yes" lookup="marlin_threshold_voltage_alarms_info" multiplier="128.0" name="L2.alarm" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.4.%i.1.2" string="yes"/>
 		<snmp_info multiplier="0.001" name="input.L2.voltage.low.warning" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.5.%i.1.2" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L2.voltage.low.critical" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.6.%i.1.2" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L2.voltage.high.warning" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.7.%i.1.2" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L2.voltage.high.critical" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.8.%i.1.2" positive="yes" writable="yes"/>
-		<snmp_info multiplier="0.001" name="input.L3.voltage" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.3.%i.1.3" power_status="yes"/>
+		<snmp_info multiplier="0.001" name="input.L3.voltage" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.3.%i.1.3"/>
 		<snmp_info flag_ok="yes" lookup="marlin_threshold_status_info" multiplier="128.0" name="input.L3.voltage.status" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.4.%i.1.3" string="yes"/>
 		<snmp_info flag_ok="yes" lookup="marlin_threshold_voltage_alarms_info" multiplier="128.0" name="L3.alarm" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.4.%i.1.3" string="yes"/>
 		<snmp_info multiplier="0.001" name="input.L3.voltage.low.warning" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.5.%i.1.3" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L3.voltage.low.critical" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.6.%i.1.3" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L3.voltage.high.warning" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.7.%i.1.3" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L3.voltage.high.critical" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.8.%i.1.3" positive="yes" writable="yes"/>
-		<snmp_info multiplier="0.001" name="input.current" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.4.%i.1.1" power_status="yes"/>
-		<snmp_info multiplier="0.001" name="input.current.nominal" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.3.%i.1.1" power_status="yes"/>
+		<snmp_info multiplier="0.001" name="input.current" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.4.%i.1.1"/>
+		<snmp_info multiplier="0.001" name="input.current.nominal" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.3.%i.1.1"/>
 		<snmp_info flag_ok="yes" lookup="marlin_threshold_status_info" multiplier="128.0" name="input.current.status" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.5.%i.1.1" string="yes"/>
 		<snmp_info flag_ok="yes" lookup="marlin_threshold_current_alarms_info" multiplier="128.0" name="ups.alarm" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.5.%i.1.1" string="yes"/>
 		<snmp_info multiplier="0.001" name="input.current.low.warning" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.6.%i.1.1" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.current.low.critical" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.7.%i.1.1" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.current.high.warning" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.8.%i.1.1" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.current.high.critical" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.9.%i.1.1" positive="yes" writable="yes"/>
-		<snmp_info multiplier="0.001" name="input.L1.current" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.4.0.1.1" power_status="yes"/>
-		<snmp_info multiplier="0.001" name="input.L1.current.nominal" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.3.%i.1.1" power_status="yes"/>
+		<snmp_info multiplier="0.001" name="input.L1.current" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.4.0.1.1"/>
+		<snmp_info multiplier="0.001" name="input.L1.current.nominal" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.3.%i.1.1"/>
 		<snmp_info flag_ok="yes" lookup="marlin_threshold_status_info" multiplier="128.0" name="input.L1.current.status" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.5.%i.1.1" string="yes"/>
 		<snmp_info flag_ok="yes" lookup="marlin_threshold_current_alarms_info" multiplier="128.0" name="L1.alarm" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.5.%i.1.1" string="yes"/>
 		<snmp_info multiplier="0.001" name="input.L1.current.low.warning" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.6.%i.1.1" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L1.current.low.critical" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.7.%i.1.1" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L1.current.high.warning" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.8.%i.1.1" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L1.current.high.critical" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.9.%i.1.1" positive="yes" writable="yes"/>
-		<snmp_info multiplier="0.001" name="input.L2.current" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.4.%i.1.2" power_status="yes"/>
-		<snmp_info multiplier="0.001" name="input.L2.current.nominal" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.3.%i.1.2" power_status="yes"/>
+		<snmp_info multiplier="0.001" name="input.L2.current" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.4.%i.1.2"/>
+		<snmp_info multiplier="0.001" name="input.L2.current.nominal" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.3.%i.1.2"/>
 		<snmp_info flag_ok="yes" lookup="marlin_threshold_status_info" multiplier="128.0" name="input.L2.current.status" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.5.%i.1.2" string="yes"/>
 		<snmp_info flag_ok="yes" lookup="marlin_threshold_current_alarms_info" multiplier="128.0" name="L2.alarm" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.5.%i.1.2" string="yes"/>
 		<snmp_info multiplier="0.001" name="input.L2.current.low.warning" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.6.%i.1.2" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L2.current.low.critical" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.7.%i.1.2" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L2.current.high.warning" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.8.%i.1.2" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L2.current.high.critical" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.9.%i.1.2" positive="yes" writable="yes"/>
-		<snmp_info multiplier="0.001" name="input.L3.current" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.4.%i.1.3" power_status="yes"/>
-		<snmp_info multiplier="0.001" name="input.L3.current.nominal" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.3.%i.1.3" power_status="yes"/>
+		<snmp_info multiplier="0.001" name="input.L3.current" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.4.%i.1.3"/>
+		<snmp_info multiplier="0.001" name="input.L3.current.nominal" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.3.%i.1.3"/>
 		<snmp_info flag_ok="yes" lookup="marlin_threshold_status_info" multiplier="128.0" name="input.L3.current.status" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.5.%i.1.3" string="yes"/>
 		<snmp_info flag_ok="yes" lookup="marlin_threshold_current_alarms_info" multiplier="128.0" name="L3.alarm" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.5.%i.1.3" string="yes"/>
 		<snmp_info multiplier="0.001" name="input.L3.current.low.warning" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.6.%i.1.3" positive="yes" writable="yes"/>
@@ -297,11 +297,11 @@
 		<snmp_info absent="yes" default="All outlets" flag_ok="yes" multiplier="20.0" name="outlet.desc" static="yes" string="yes" writable="yes"/>
 		<snmp_info default="no" lookup="marlin_unit_switchability_info" multiplier="128.0" name="outlet.switchable" oid=".1.3.6.1.4.1.534.6.6.7.1.2.1.10.%i" static="yes" string="yes" unique="yes"/>
 		<snmp_info default="no" flag_ok="yes" lookup="g2_unit_outlet_switchability_info" multiplier="128.0" name="outlet.switchable" oid=".1.3.6.1.4.1.534.6.6.7.6.6.1.3.%i.1" static="yes" string="yes" type_daisy="1" unique="yes"/>
-		<snmp_info multiplier="0.1" name="outlet.frequency" oid=".1.3.6.1.4.1.534.6.6.7.3.1.1.3.%i.1" power_status="yes"/>
-		<snmp_info multiplier="0.001" name="outlet.voltage" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.3.%i.1.1" power_status="yes"/>
-		<snmp_info multiplier="0.01" name="outlet.current" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.4.%i.1.1" power_status="yes"/>
-		<snmp_info multiplier="1.0" name="outlet.realpower" oid=".1.3.6.1.4.1.534.6.6.7.3.4.1.4.%i.1.4" power_status="yes"/>
-		<snmp_info multiplier="1.0" name="outlet.power" oid=".1.3.6.1.4.1.534.6.6.7.3.4.1.3.%i.1.4" power_status="yes"/>
+		<snmp_info multiplier="0.1" name="outlet.frequency" oid=".1.3.6.1.4.1.534.6.6.7.3.1.1.3.%i.1"/>
+		<snmp_info multiplier="0.001" name="outlet.voltage" oid=".1.3.6.1.4.1.534.6.6.7.3.2.1.3.%i.1.1"/>
+		<snmp_info multiplier="0.01" name="outlet.current" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.4.%i.1.1"/>
+		<snmp_info multiplier="1.0" name="outlet.realpower" oid=".1.3.6.1.4.1.534.6.6.7.3.4.1.4.%i.1.4"/>
+		<snmp_info multiplier="1.0" name="outlet.power" oid=".1.3.6.1.4.1.534.6.6.7.3.4.1.3.%i.1.4"/>
 		<snmp_info flag_ok="yes" multiplier="128.0" name="outlet.%i.desc" oid=".1.3.6.1.4.1.534.6.6.7.6.1.1.3.%i.%i" outlet="yes" semistatic="yes" string="yes" type_daisy="1" writable="yes"/>
 		<snmp_info flag_ok="yes" lookup="marlin_outlet_status_info" multiplier="128.0" name="outlet.%i.status" oid=".1.3.6.1.4.1.534.6.6.7.6.6.1.2.%i.%i" outlet="yes" string="yes" type_daisy="1"/>
 		<snmp_info multiplier="1.0" name="outlet.%i.id" oid=".1.3.6.1.4.1.534.6.6.7.6.6.1.7.%i.%i" outlet="yes" static="yes" type_daisy="1"/>

--- a/scripts/DMF/dmfsnmp/eaton-pdu-pulizzi-mib.dmf
+++ b/scripts/DMF/dmfsnmp/eaton-pdu-pulizzi-mib.dmf
@@ -15,16 +15,16 @@
 		<snmp_info absent="yes" default="EATON | Powerware" flag_ok="yes" multiplier="128.0" name="device.mfr" static="yes" string="yes"/>
 		<snmp_info default="Switched ePDU" flag_ok="yes" multiplier="128.0" name="device.model" oid=".1.3.6.1.4.1.20677.2.1.1.0" static="yes" string="yes"/>
 		<snmp_info absent="yes" default="pdu" flag_ok="yes" multiplier="128.0" name="device.type" static="yes" string="yes"/>
-		<snmp_info default="unknown" multiplier="128.0" name="device.macaddr" oid=".1.3.6.1.4.1.20677.2.2.6.0" power_status="yes" string="yes"/>
+		<snmp_info default="unknown" multiplier="128.0" name="device.macaddr" oid=".1.3.6.1.4.1.20677.2.2.6.0" string="yes"/>
 		<snmp_info absent="yes" default="EATON" flag_ok="yes" multiplier="128.0" name="ups.mfr" static="yes" string="yes"/>
 		<snmp_info default="Switched ePDU" flag_ok="yes" multiplier="128.0" name="ups.model" oid=".1.3.6.1.4.1.20677.2.1.1.0" static="yes" string="yes"/>
 		<snmp_info default="" flag_ok="yes" multiplier="128.0" name="ups.date" oid=".1.3.6.1.4.1.20677.2.1.4.0" static="yes" string="yes"/>
 		<snmp_info default="" flag_ok="yes" multiplier="128.0" name="ups.time" oid=".1.3.6.1.4.1.20677.2.1.3.0" static="yes" string="yes"/>
 		<snmp_info absent="yes" default="0" flag_ok="yes" multiplier="1.0" name="outlet.id" static="yes"/>
 		<snmp_info absent="yes" default="All outlets" flag_ok="yes" multiplier="20.0" name="outlet.desc" static="yes" string="yes" writable="yes"/>
-		<snmp_info multiplier="1.0" name="outlet.current" oid=".1.3.6.1.4.1.20677.2.8.6.4.2.0" power_status="yes"/>
-		<snmp_info multiplier="1.0" name="outlet.voltage" oid=".1.3.6.1.4.1.20677.2.8.6.4.1.0" power_status="yes"/>
-		<snmp_info multiplier="1.0" name="outlet.power" oid=".1.3.6.1.4.1.20677.2.8.6.4.3.0" power_status="yes"/>
+		<snmp_info multiplier="1.0" name="outlet.current" oid=".1.3.6.1.4.1.20677.2.8.6.4.2.0"/>
+		<snmp_info multiplier="1.0" name="outlet.voltage" oid=".1.3.6.1.4.1.20677.2.8.6.4.1.0"/>
+		<snmp_info multiplier="1.0" name="outlet.power" oid=".1.3.6.1.4.1.20677.2.8.6.4.3.0"/>
 		<snmp_info flag_ok="yes" multiplier="128.0" name="outlet.%i.desc" oid=".1.3.6.1.4.1.20677.2.6.1.%i.1.0" outlet="yes" static="yes" string="yes" writable="yes"/>
 		<snmp_info flag_ok="yes" lookup="pulizzi_sw_outlet_status_info" multiplier="128.0" name="outlet.%i.status" oid=".1.3.6.1.4.1.20677.2.6.3.%i.0" outlet="yes" string="yes"/>
 		<snmp_info absent="yes" default="%i" flag_ok="yes" multiplier="1.0" name="outlet.%i.id" outlet="yes" static="yes"/>
@@ -35,9 +35,9 @@
 		<snmp_info command="yes" default="2" multiplier="1.0" name="load.off" oid=".1.3.6.1.4.1.20677.2.6.2.1.0"/>
 		<snmp_info command="yes" default="3" multiplier="1.0" name="load.on.delay" oid=".1.3.6.1.4.1.20677.2.6.2.1.0"/>
 		<snmp_info command="yes" default="4" multiplier="1.0" name="load.off.delay" oid=".1.3.6.1.4.1.20677.2.6.2.1.0"/>
-		<snmp_info battery_status="yes" command="yes" default="1" multiplier="1.0" name="outlet.%i.load.on" oid=".1.3.6.1.4.1.20677.2.6.2.%i.0" outlet="yes"/>
-		<snmp_info battery_status="yes" command="yes" default="2" multiplier="1.0" name="outlet.%i.load.off" oid=".1.3.6.1.4.1.20677.2.6.2.%i.0" outlet="yes"/>
-		<snmp_info battery_status="yes" command="yes" default="3" multiplier="1.0" name="outlet.%i.load.cycle" oid=".1.3.6.1.4.1.20677.2.6.2.%i.0" outlet="yes"/>
+		<snmp_info command="yes" command_offset="yes" default="1" multiplier="1.0" name="outlet.%i.load.on" oid=".1.3.6.1.4.1.20677.2.6.2.%i.0" outlet="yes"/>
+		<snmp_info command="yes" command_offset="yes" default="2" multiplier="1.0" name="outlet.%i.load.off" oid=".1.3.6.1.4.1.20677.2.6.2.%i.0" outlet="yes"/>
+		<snmp_info command="yes" command_offset="yes" default="3" multiplier="1.0" name="outlet.%i.load.cycle" oid=".1.3.6.1.4.1.20677.2.6.2.%i.0" outlet="yes"/>
 	</snmp>
 	<mib2nut auto_check=".1.3.6.1.4.1.20677.1" mib_name="pulizzi_switched1" name="pulizzi_switched1" oid=".1.3.6.1.4.1.20677.1" snmp_info="eaton_pulizzi_switched_mib" version="0.3"/>
 	<mib2nut auto_check=".1.3.6.1.4.1.20677.1" mib_name="pulizzi_switched2" name="pulizzi_switched2" oid=".1.3.6.1.4.1.20677.2" snmp_info="eaton_pulizzi_switched_mib" version="0.3"/>

--- a/scripts/DMF/dmfsnmp/eaton-pdu-revelation-mib.dmf
+++ b/scripts/DMF/dmfsnmp/eaton-pdu-revelation-mib.dmf
@@ -28,14 +28,14 @@
 		<snmp_info default="" flag_ok="yes" multiplier="128.0" name="ups.serial" oid=".1.3.6.1.4.1.534.6.6.6.1.1.2.0" static="yes" string="yes"/>
 		<snmp_info default="" flag_ok="yes" multiplier="128.0" name="ups.firmware" oid=".1.3.6.1.4.1.534.6.6.6.1.1.1.0" static="yes" string="yes"/>
 		<snmp_info absent="yes" default="pdu" flag_ok="yes" multiplier="128.0" name="ups.type" static="yes" string="yes"/>
-		<snmp_info multiplier="1.0" name="ups.temperature" oid=".1.3.6.1.4.1.534.6.6.6.1.3.1.5.0" power_status="yes"/>
+		<snmp_info multiplier="1.0" name="ups.temperature" oid=".1.3.6.1.4.1.534.6.6.6.1.3.1.5.0"/>
 		<snmp_info absent="yes" default="0" flag_ok="yes" multiplier="1.0" name="outlet.id" static="yes"/>
 		<snmp_info absent="yes" default="All outlets" flag_ok="yes" multiplier="20.0" name="outlet.desc" static="yes" string="yes" writable="yes"/>
-		<snmp_info default="0" multiplier="1.0" name="outlet.count" oid=".1.3.6.1.4.1.534.6.6.6.1.2.1.0" power_status="yes"/>
-		<snmp_info multiplier="0.001" name="outlet.current" oid=".1.3.6.1.4.1.534.6.6.6.1.3.1.1.0" power_status="yes"/>
-		<snmp_info multiplier="0.001" name="outlet.voltage" oid=".1.3.6.1.4.1.534.6.6.6.1.3.1.2.0" power_status="yes"/>
-		<snmp_info multiplier="1.0" name="outlet.realpower" oid=".1.3.6.1.4.1.534.6.6.6.1.3.1.3.0" power_status="yes"/>
-		<snmp_info multiplier="1.0" name="outlet.power" oid=".1.3.6.1.4.1.534.6.6.6.1.3.1.4.0" power_status="yes"/>
+		<snmp_info default="0" multiplier="1.0" name="outlet.count" oid=".1.3.6.1.4.1.534.6.6.6.1.2.1.0"/>
+		<snmp_info multiplier="0.001" name="outlet.current" oid=".1.3.6.1.4.1.534.6.6.6.1.3.1.1.0"/>
+		<snmp_info multiplier="0.001" name="outlet.voltage" oid=".1.3.6.1.4.1.534.6.6.6.1.3.1.2.0"/>
+		<snmp_info multiplier="1.0" name="outlet.realpower" oid=".1.3.6.1.4.1.534.6.6.6.1.3.1.3.0"/>
+		<snmp_info multiplier="1.0" name="outlet.power" oid=".1.3.6.1.4.1.534.6.6.6.1.3.1.4.0"/>
 		<snmp_info default="yes" lookup="revelation_outlet_switchability_info" multiplier="1.0" name="outlet.%i.switchable" oid=".1.3.6.1.4.1.534.6.6.6.1.2.2.1.3.%i" outlet="yes" static="yes"/>
 		<snmp_info absent="yes" default="%i" flag_ok="yes" multiplier="1.0" name="outlet.%i.id" outlet="yes" static="yes"/>
 		<snmp_info multiplier="128.0" name="outlet.%i.desc" oid=".1.3.6.1.4.1.534.6.6.6.1.2.2.1.2.%i" outlet="yes" string="yes" writable="yes"/>

--- a/scripts/DMF/dmfsnmp/emerson-avocent-pdu-mib.dmf
+++ b/scripts/DMF/dmfsnmp/emerson-avocent-pdu-mib.dmf
@@ -22,8 +22,8 @@
 		<snmp_info default="" flag_ok="yes" multiplier="128.0" name="ups.macaddr" oid=".1.3.6.1.2.1.2.2.1.6.1" static="yes" string="yes"/>
 		<snmp_info absent="yes" default="0" flag_ok="yes" multiplier="1.0" name="outlet.id" static="yes"/>
 		<snmp_info absent="yes" default="All outlets" flag_ok="yes" multiplier="20.0" name="outlet.desc" static="yes" string="yes" writable="yes"/>
-		<snmp_info default="0" flag_ok="yes" multiplier="1.0" name="outlet.count" oid=".1.3.6.1.4.1.10418.17.2.5.3.1.8.1.%i" static="yes" type_daisy="2"/>
-		<snmp_info lookup="avocent_outlet_status_info" multiplier="128.0" name="outlet.%i.status" oid=".1.3.6.1.4.1.10418.17.2.5.5.1.5.1.%i.%i" outlet="yes" string="yes" type_daisy="2"/>
+		<snmp_info default="0" flag_ok="yes" multiplier="1.0" name="outlet.count" oid=".1.3.6.1.4.1.10418.17.2.5.3.1.8.1.%i" static="yes" zero_invalid="yes"/>
+		<snmp_info lookup="avocent_outlet_status_info" multiplier="128.0" name="outlet.%i.status" oid=".1.3.6.1.4.1.10418.17.2.5.5.1.5.1.%i.%i" outlet="yes" string="yes" type_daisy="1" zero_invalid="yes"/>
 		<snmp_info absent="yes" flag_ok="yes" multiplier="1.0" name="outlet.%i.id" oid=".1.3.6.1.4.1.10418.17.2.5.5.1.3.1.%i.%i" outlet="yes" static="yes" type_daisy="1"/>
 		<snmp_info multiplier="128.0" na_invalid="yes" name="outlet.%i.desc" oid=".1.3.6.1.4.1.10418.17.2.5.5.1.4.1.%i.%i" outlet="yes" string="yes" type_daisy="1" writable="yes"/>
 		<snmp_info multiplier="0.1" name="outlet.%i.current" oid=".1.3.6.1.4.1.10418.17.2.5.5.1.50.1.%i.%i" outlet="yes" type_daisy="1"/>

--- a/scripts/DMF/dmfsnmp/hpe-pdu-mib.dmf
+++ b/scripts/DMF/dmfsnmp/hpe-pdu-mib.dmf
@@ -129,42 +129,42 @@
 		<snmp_info default="" flag_ok="yes" multiplier="128.0" name="ups.firmware" oid=".1.3.6.1.4.1.232.165.7.1.2.1.5.%i" string="yes"/>
 		<snmp_info absent="yes" default="pdu" flag_ok="yes" multiplier="128.0" name="ups.type" static="yes" string="yes"/>
 		<snmp_info lookup="hpe_pdu_input_type_info" multiplier="1.0" name="input.phases" oid=".1.3.6.1.4.1.232.165.7.2.1.1.1.%i" static="yes"/>
-		<snmp_info multiplier="0.1" name="input.frequency" oid=".1.3.6.1.4.1.232.165.7.2.1.1.2.%i" power_status="yes"/>
+		<snmp_info multiplier="0.1" name="input.frequency" oid=".1.3.6.1.4.1.232.165.7.2.1.1.2.%i"/>
 		<snmp_info flag_ok="yes" lookup="hpe_pdu_threshold_frequency_status_info" multiplier="128.0" name="input.frequency.status" oid=".1.3.6.1.4.1.232.165.7.2.1.1.3.%i" string="yes"/>
 		<snmp_info flag_ok="yes" lookup="hpe_pdu_threshold_frequency_alarm_info" multiplier="128.0" name="ups.alarm" oid=".1.3.6.1.4.1.232.165.7.2.1.1.3.%i" string="yes"/>
 		<snmp_info flag_ok="yes" multiplier="1.0" name="input.load" oid=".1.3.6.1.4.1.534.6.6.7.3.3.1.11.%i.1.1" positive="yes"/>
 		<snmp_info flag_ok="yes" multiplier="1.0" name="input.L1.load" oid=".1.3.6.1.4.1.232.165.7.2.2.1.18.%i.1" positive="yes"/>
 		<snmp_info flag_ok="yes" multiplier="1.0" name="input.L1.load" oid=".1.3.6.1.4.1.232.165.7.2.2.1.18.%i.2" positive="yes"/>
 		<snmp_info flag_ok="yes" multiplier="1.0" name="input.L1.load" oid=".1.3.6.1.4.1.232.165.7.2.2.1.18.%i.3" positive="yes"/>
-		<snmp_info multiplier="0.001" name="input.voltage" oid=".1.3.6.1.4.1.232.165.7.2.2.1.3.%i.1" power_status="yes"/>
+		<snmp_info multiplier="0.001" name="input.voltage" oid=".1.3.6.1.4.1.232.165.7.2.2.1.3.%i.1"/>
 		<snmp_info flag_ok="yes" lookup="hpe_pdu_threshold_status_info" multiplier="128.0" name="input.voltage.status" oid=".1.3.6.1.4.1.232.165.7.2.2.1.4.%i.1" string="yes"/>
 		<snmp_info flag_ok="yes" lookup="hpe_pdu_threshold_voltage_alarms_info" multiplier="128.0" name="ups.alarm" oid=".1.3.6.1.4.1.232.165.7.2.2.1.4.%i.1" string="yes"/>
 		<snmp_info multiplier="0.001" name="input.voltage.low.warning" oid=".1.3.6.1.4.1.232.165.7.2.2.1.5.%i.1" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.voltage.low.critical" oid=".1.3.6.1.4.1.232.165.7.2.2.1.6.%i.1" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.voltage.high.warning" oid=".1.3.6.1.4.1.232.165.7.2.2.1.7.%i.1" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.voltage.high.critical" oid=".1.3.6.1.4.1.232.165.7.2.2.1.8.%i.1" positive="yes" writable="yes"/>
-		<snmp_info multiplier="0.001" name="input.L1.voltage" oid=".1.3.6.1.4.1.232.165.7.2.2.1.3.%i.1" power_status="yes"/>
+		<snmp_info multiplier="0.001" name="input.L1.voltage" oid=".1.3.6.1.4.1.232.165.7.2.2.1.3.%i.1"/>
 		<snmp_info flag_ok="yes" lookup="hpe_pdu_threshold_status_info" multiplier="128.0" name="input.L1.voltage.status" oid=".1.3.6.1.4.1.232.165.7.2.2.1.4.%i.1" string="yes"/>
 		<snmp_info flag_ok="yes" lookup="hpe_pdu_threshold_voltage_alarms_info" multiplier="128.0" name="L1.alarm" oid=".1.3.6.1.4.1.232.165.7.2.2.1.4.%i.1" string="yes"/>
 		<snmp_info multiplier="0.001" name="input.L1.voltage.low.warning" oid=".1.3.6.1.4.1.232.165.7.2.2.1.5.%i.1" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L1.voltage.low.critical" oid=".1.3.6.1.4.1.232.165.7.2.2.1.6.%i.1" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L1.voltage.high.warning" oid=".1.3.6.1.4.1.232.165.7.2.2.1.7.%i.1" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L1.voltage.high.critical" oid=".1.3.6.1.4.1.232.165.7.2.2.1.8.%i.1" positive="yes" writable="yes"/>
-		<snmp_info multiplier="0.001" name="input.L2.voltage" oid=".1.3.6.1.4.1.232.165.7.2.2.1.3.%i.2" power_status="yes"/>
+		<snmp_info multiplier="0.001" name="input.L2.voltage" oid=".1.3.6.1.4.1.232.165.7.2.2.1.3.%i.2"/>
 		<snmp_info flag_ok="yes" lookup="hpe_pdu_threshold_status_info" multiplier="128.0" name="input.L2.voltage.status" oid=".1.3.6.1.4.1.232.165.7.2.2.1.4.%i.2" string="yes"/>
 		<snmp_info flag_ok="yes" lookup="hpe_pdu_threshold_voltage_alarms_info" multiplier="128.0" name="L2.alarm" oid=".1.3.6.1.4.1.232.165.7.2.2.1.4.%i.2" string="yes"/>
 		<snmp_info multiplier="0.001" name="input.L2.voltage.low.warning" oid=".1.3.6.1.4.1.232.165.7.2.2.1.5.%i.2" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L2.voltage.low.critical" oid=".1.3.6.1.4.1.232.165.7.2.2.1.6.%i.2" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L2.voltage.high.warning" oid=".1.3.6.1.4.1.232.165.7.2.2.1.7.%i.2" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L2.voltage.high.critical" oid=".1.3.6.1.4.1.232.165.7.2.2.1.8.%i.2" positive="yes" writable="yes"/>
-		<snmp_info multiplier="0.001" name="input.L3.voltage" oid=".1.3.6.1.4.1.232.165.7.2.2.1.3.%i.3" power_status="yes"/>
+		<snmp_info multiplier="0.001" name="input.L3.voltage" oid=".1.3.6.1.4.1.232.165.7.2.2.1.3.%i.3"/>
 		<snmp_info flag_ok="yes" lookup="hpe_pdu_threshold_status_info" multiplier="128.0" name="input.L3.voltage.status" oid=".1.3.6.1.4.1.232.165.7.2.2.1.4.%i.3" string="yes"/>
 		<snmp_info flag_ok="yes" lookup="hpe_pdu_threshold_voltage_alarms_info" multiplier="128.0" name="L3.alarm" oid=".1.3.6.1.4.1.232.165.7.2.2.1.4.%i.3" string="yes"/>
 		<snmp_info multiplier="0.001" name="input.L3.voltage.low.warning" oid=".1.3.6.1.4.1.232.165.7.2.2.1.5.%i.3" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L3.voltage.low.critical" oid=".1.3.6.1.4.1.232.165.7.2.2.1.6.%i.3" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L3.voltage.high.warning" oid=".1.3.6.1.4.1.232.165.7.2.2.1.7.%i.3" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L3.voltage.high.critical" oid=".1.3.6.1.4.1.232.165.7.2.2.1.8.%i.3" positive="yes" writable="yes"/>
-		<snmp_info multiplier="0.001" name="input.current" oid=".1.3.6.1.4.1.232.165.7.2.2.1.11.%i.1" power_status="yes"/>
+		<snmp_info multiplier="0.001" name="input.current" oid=".1.3.6.1.4.1.232.165.7.2.2.1.11.%i.1"/>
 		<snmp_info multiplier="0.001" name="input.current.nominal" oid=".1.3.6.1.4.1.232.165.7.2.2.1.10.%i.1" positive="yes"/>
 		<snmp_info flag_ok="yes" lookup="hpe_pdu_threshold_status_info" multiplier="128.0" name="input.current.status" oid=".1.3.6.1.4.1.232.165.7.2.2.1.12.%i.1" string="yes"/>
 		<snmp_info flag_ok="yes" lookup="hpe_pdu_threshold_current_alarms_info" multiplier="128.0" name="ups.alarm" oid=".1.3.6.1.4.1.232.165.7.2.2.1.12.%i.1" string="yes"/>
@@ -172,7 +172,7 @@
 		<snmp_info multiplier="0.001" name="input.current.low.critical" oid=".1.3.6.1.4.1.232.165.7.2.2.1.14.%i.1" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.current.high.warning" oid=".1.3.6.1.4.1.232.165.7.2.2.1.15.%i.1" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.current.high.critical" oid=".1.3.6.1.4.1.232.165.7.2.2.1.16.%i.1" positive="yes" writable="yes"/>
-		<snmp_info multiplier="0.001" name="input.L1.current" oid=".1.3.6.1.4.1.232.165.7.2.2.1.11.%i.1" power_status="yes"/>
+		<snmp_info multiplier="0.001" name="input.L1.current" oid=".1.3.6.1.4.1.232.165.7.2.2.1.11.%i.1"/>
 		<snmp_info multiplier="0.001" name="input.L1.current.nominal" oid=".1.3.6.1.4.1.232.165.7.2.2.1.10.%i.1" positive="yes"/>
 		<snmp_info flag_ok="yes" lookup="hpe_pdu_threshold_status_info" multiplier="128.0" name="input.L1.current.status" oid=".1.3.6.1.4.1.232.165.7.2.2.1.12.%i.1" string="yes"/>
 		<snmp_info flag_ok="yes" lookup="hpe_pdu_threshold_current_alarms_info" multiplier="128.0" name="L1.alarm" oid=".1.3.6.1.4.1.232.165.7.2.2.1.12.%i.1" string="yes"/>
@@ -180,7 +180,7 @@
 		<snmp_info multiplier="0.001" name="input.L1.current.low.critical" oid=".1.3.6.1.4.1.232.165.7.2.2.1.14.%i.1" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L1.current.high.warning" oid=".1.3.6.1.4.1.232.165.7.2.2.1.15.%i.1" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L1.current.high.critical" oid=".1.3.6.1.4.1.232.165.7.2.2.1.16.%i.1" positive="yes" writable="yes"/>
-		<snmp_info multiplier="0.001" name="input.L2.current" oid=".1.3.6.1.4.1.232.165.7.2.2.1.11.%i.2" power_status="yes"/>
+		<snmp_info multiplier="0.001" name="input.L2.current" oid=".1.3.6.1.4.1.232.165.7.2.2.1.11.%i.2"/>
 		<snmp_info multiplier="0.001" name="input.L2.current.nominal" oid=".1.3.6.1.4.1.232.165.7.2.2.1.10.%i.2" positive="yes"/>
 		<snmp_info flag_ok="yes" lookup="hpe_pdu_threshold_status_info" multiplier="128.0" name="input.L2.current.status" oid=".1.3.6.1.4.1.232.165.7.2.2.1.12.%i.2" string="yes"/>
 		<snmp_info flag_ok="yes" lookup="hpe_pdu_threshold_current_alarms_info" multiplier="128.0" name="L2.alarm" oid=".1.3.6.1.4.1.232.165.7.2.2.1.12.%i.2" string="yes"/>
@@ -188,7 +188,7 @@
 		<snmp_info multiplier="0.001" name="input.L2.current.low.critical" oid=".1.3.6.1.4.1.232.165.7.2.2.1.14.%i.2" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L2.current.high.warning" oid=".1.3.6.1.4.1.232.165.7.2.2.1.15.%i.2" positive="yes" writable="yes"/>
 		<snmp_info multiplier="0.001" name="input.L2.current.high.critical" oid=".1.3.6.1.4.1.232.165.7.2.2.1.16.%i.2" positive="yes" writable="yes"/>
-		<snmp_info multiplier="0.001" name="input.L3.current" oid=".1.3.6.1.4.1.232.165.7.2.2.1.11.%i.3" power_status="yes"/>
+		<snmp_info multiplier="0.001" name="input.L3.current" oid=".1.3.6.1.4.1.232.165.7.2.2.1.11.%i.3"/>
 		<snmp_info multiplier="0.001" name="input.L3.current.nominal" oid=".1.3.6.1.4.1.232.165.7.2.2.1.10.%i.3" positive="yes"/>
 		<snmp_info flag_ok="yes" lookup="hpe_pdu_threshold_status_info" multiplier="128.0" name="input.L3.current.status" oid=".1.3.6.1.4.1.232.165.7.2.2.1.12.%i.3" string="yes"/>
 		<snmp_info flag_ok="yes" lookup="hpe_pdu_threshold_current_alarms_info" multiplier="128.0" name="L2.alarm" oid=".1.3.6.1.4.1.232.165.7.2.2.1.12.%i.2" string="yes"/>

--- a/scripts/DMF/dmfsnmp/huawei-mib.dmf
+++ b/scripts/DMF/dmfsnmp/huawei-mib.dmf
@@ -70,7 +70,7 @@
 		<snmp_info flag_ok="yes" multiplier="128.0" name="ups.serial" oid=".1.3.6.1.4.1.2011.6.174.1.2.100.1.5.1" static="yes" string="yes"/>
 		<snmp_info flag_ok="yes" lookup="huawei_supplymethod_info" multiplier="1.0" name="ups.status" oid=".1.3.6.1.4.1.2011.6.174.1.2.101.1.1.1"/>
 		<snmp_info battery_status="yes" flag_ok="yes" lookup="huawei_battstate_info" multiplier="1.0" name="ups.status" oid=".1.3.6.1.4.1.2011.6.174.1.2.101.1.3.1"/>
-		<snmp_info default="" lookup="huawei_test_result_info" multiplier="128.0" name="ups.test.result" oid=".1.3.6.1.2.1.33.1.7.3.0" power_status="yes" string="yes"/>
+		<snmp_info default="" lookup="huawei_test_result_info" multiplier="128.0" name="ups.test.result" oid=".1.3.6.1.2.1.33.1.7.3.0" string="yes"/>
 		<snmp_info absent="yes" default="3" flag_ok="yes" lookup="huawei_phase_info" multiplier="128.0" name="input.phases" oid=".1.3.6.1.4.1.2011.6.174.1.102.100.1.8" string="yes"/>
 		<snmp_info flag_ok="yes" multiplier="0.1" name="input.L1-N.voltage" oid=".1.3.6.1.4.1.2011.6.174.1.3.100.1.1.1"/>
 		<snmp_info flag_ok="yes" multiplier="0.1" name="input.L2-N.voltage" oid=".1.3.6.1.4.1.2011.6.174.1.3.100.1.2.1"/>

--- a/scripts/DMF/dmfsnmp/ietf-mib.dmf
+++ b/scripts/DMF/dmfsnmp/ietf-mib.dmf
@@ -51,12 +51,12 @@
 		<snmp_info default="" multiplier="128.0" name="ups.firmware" oid="1.3.6.1.2.1.33.1.1.3.0" static="yes" string="yes"/>
 		<snmp_info default="" multiplier="128.0" name="ups.firmware.aux" oid="1.3.6.1.2.1.33.1.1.4.0" static="yes" string="yes"/>
 		<snmp_info battery_status="yes" default="" lookup="ietf_battery_info" multiplier="128.0" name="ups.status" oid="1.3.6.1.2.1.33.1.2.1.0" string="yes"/>
-		<snmp_info default="" multiplier="60.0" name="battery.runtime" oid="1.3.6.1.2.1.33.1.2.3.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="battery.charge" oid="1.3.6.1.2.1.33.1.2.4.0" power_status="yes"/>
-		<snmp_info default="" multiplier="0.1" name="battery.voltage" oid="1.3.6.1.2.1.33.1.2.5.0" power_status="yes"/>
-		<snmp_info default="" multiplier="0.1" name="battery.current" oid="1.3.6.1.2.1.33.1.2.6.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="battery.temperature" oid="1.3.6.1.2.1.33.1.2.7.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="input.phases" oid="1.3.6.1.2.1.33.1.3.2.0" power_status="yes"/>
+		<snmp_info default="" multiplier="60.0" name="battery.runtime" oid="1.3.6.1.2.1.33.1.2.3.0"/>
+		<snmp_info default="" multiplier="1.0" name="battery.charge" oid="1.3.6.1.2.1.33.1.2.4.0"/>
+		<snmp_info default="" multiplier="0.1" name="battery.voltage" oid="1.3.6.1.2.1.33.1.2.5.0"/>
+		<snmp_info default="" multiplier="0.1" name="battery.current" oid="1.3.6.1.2.1.33.1.2.6.0"/>
+		<snmp_info default="" multiplier="1.0" name="battery.temperature" oid="1.3.6.1.2.1.33.1.2.7.0"/>
+		<snmp_info default="" multiplier="1.0" name="input.phases" oid="1.3.6.1.2.1.33.1.3.2.0"/>
 		<snmp_info default="" input_1_phase="yes" multiplier="0.1" name="input.frequency" oid="1.3.6.1.2.1.33.1.3.3.1.2.1"/>
 		<snmp_info default="" input_3_phase="yes" multiplier="0.1" name="input.L1.frequency" oid="1.3.6.1.2.1.33.1.3.3.1.2.1"/>
 		<snmp_info default="" input_3_phase="yes" multiplier="0.1" name="input.L2.frequency" oid="1.3.6.1.2.1.33.1.3.3.1.2.2"/>
@@ -74,8 +74,8 @@
 		<snmp_info default="" input_3_phase="yes" multiplier="1.0" name="input.L2.realpower" oid="1.3.6.1.2.1.33.1.3.3.1.5.2"/>
 		<snmp_info default="" input_3_phase="yes" multiplier="1.0" name="input.L3.realpower" oid="1.3.6.1.2.1.33.1.3.3.1.5.3"/>
 		<snmp_info default="" lookup="ietf_power_source_info" multiplier="128.0" name="ups.status" oid="1.3.6.1.2.1.33.1.4.1.0" power_status="yes" string="yes"/>
-		<snmp_info default="" multiplier="0.1" name="output.frequency" oid="1.3.6.1.2.1.33.1.4.2.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="output.phases" oid="1.3.6.1.2.1.33.1.4.3.0" power_status="yes"/>
+		<snmp_info default="" multiplier="0.1" name="output.frequency" oid="1.3.6.1.2.1.33.1.4.2.0"/>
+		<snmp_info default="" multiplier="1.0" name="output.phases" oid="1.3.6.1.2.1.33.1.4.3.0"/>
 		<snmp_info default="" multiplier="1.0" name="output.voltage" oid="1.3.6.1.2.1.33.1.4.4.1.2.1" output_1_phase="yes"/>
 		<snmp_info default="" multiplier="1.0" name="output.L1-N.voltage" oid="1.3.6.1.2.1.33.1.4.4.1.2.1" output_3_phase="yes"/>
 		<snmp_info default="" multiplier="1.0" name="output.L2-N.voltage" oid="1.3.6.1.2.1.33.1.4.4.1.2.2" output_3_phase="yes"/>
@@ -92,7 +92,7 @@
 		<snmp_info default="" multiplier="1.0" name="output.L1.power.percent" oid="1.3.6.1.2.1.33.1.4.4.1.5.1" output_3_phase="yes"/>
 		<snmp_info default="" multiplier="1.0" name="output.L2.power.percent" oid="1.3.6.1.2.1.33.1.4.4.1.5.2" output_3_phase="yes"/>
 		<snmp_info default="" multiplier="1.0" name="output.L3.power.percent" oid="1.3.6.1.2.1.33.1.4.4.1.5.3" output_3_phase="yes"/>
-		<snmp_info default="" multiplier="1.0" name="input.bypass.phases" oid="1.3.6.1.2.1.33.1.5.2.0" power_status="yes"/>
+		<snmp_info default="" multiplier="1.0" name="input.bypass.phases" oid="1.3.6.1.2.1.33.1.5.2.0"/>
 		<snmp_info bypass_1_phase="yes" bypass_3_phase="yes" default="" multiplier="0.1" name="input.bypass.frequency" oid="1.3.6.1.2.1.33.1.5.1.0"/>
 		<snmp_info bypass_1_phase="yes" default="" multiplier="1.0" name="input.bypass.voltage" oid="1.3.6.1.2.1.33.1.5.3.1.2.1"/>
 		<snmp_info bypass_3_phase="yes" default="" multiplier="1.0" name="input.bypass.L1-N.voltage" oid="1.3.6.1.2.1.33.1.5.3.1.2.1"/>
@@ -106,32 +106,32 @@
 		<snmp_info bypass_3_phase="yes" default="" multiplier="1.0" name="input.bypass.L1.realpower" oid="1.3.6.1.2.1.33.1.5.3.1.4.1"/>
 		<snmp_info bypass_3_phase="yes" default="" multiplier="1.0" name="input.bypass.L2.realpower" oid="1.3.6.1.2.1.33.1.5.3.1.4.2"/>
 		<snmp_info bypass_3_phase="yes" default="" multiplier="1.0" name="input.bypass.L3.realpower" oid="1.3.6.1.2.1.33.1.5.3.1.4.3"/>
-		<snmp_info default="" lookup="ietf_overload_info" multiplier="128.0" name="ups.status" oid="1.3.6.1.2.1.33.1.6.3.8" power_status="yes" string="yes"/>
-		<snmp_info default="" lookup="ietf_test_active_info" multiplier="128.0" name="ups.status" oid="1.3.6.1.2.1.33.1.7.1.0" power_status="yes" string="yes"/>
+		<snmp_info default="" lookup="ietf_overload_info" multiplier="128.0" name="ups.status" oid="1.3.6.1.2.1.33.1.6.3.8" string="yes"/>
+		<snmp_info default="" lookup="ietf_test_active_info" multiplier="128.0" name="ups.status" oid="1.3.6.1.2.1.33.1.7.1.0" string="yes"/>
 		<snmp_info command="yes" default="0" multiplier="1.0" name="test.battery.stop" oid="1.3.6.1.2.1.33.1.7.1.0"/>
 		<snmp_info command="yes" default="0" multiplier="1.0" name="test.battery.start" oid="1.3.6.1.2.1.33.1.7.1.0"/>
 		<snmp_info command="yes" default="0" multiplier="1.0" name="test.battery.start.quick" oid="1.3.6.1.2.1.33.1.7.1.0"/>
 		<snmp_info command="yes" default="0" multiplier="1.0" name="test.battery.start.deep" oid="1.3.6.1.2.1.33.1.7.1.0"/>
-		<snmp_info default="" lookup="ietf_test_result_info" multiplier="128.0" name="ups.test.result" oid="1.3.6.1.2.1.33.1.7.3.0" power_status="yes" string="yes"/>
-		<snmp_info default="" multiplier="8.0" name="ups.timer.shutdown" oid="1.3.6.1.2.1.33.1.8.2.0" power_status="yes" string="yes" writable="yes"/>
+		<snmp_info default="" lookup="ietf_test_result_info" multiplier="128.0" name="ups.test.result" oid="1.3.6.1.2.1.33.1.7.3.0" string="yes"/>
+		<snmp_info default="" multiplier="8.0" name="ups.timer.shutdown" oid="1.3.6.1.2.1.33.1.8.2.0" string="yes" writable="yes"/>
 		<snmp_info command="yes" default="0" multiplier="1.0" name="load.off" oid="1.3.6.1.2.1.33.1.8.2.0"/>
-		<snmp_info default="" multiplier="8.0" name="ups.timer.start" oid="1.3.6.1.2.1.33.1.8.3.0" power_status="yes" string="yes" writable="yes"/>
+		<snmp_info default="" multiplier="8.0" name="ups.timer.start" oid="1.3.6.1.2.1.33.1.8.3.0" string="yes" writable="yes"/>
 		<snmp_info command="yes" default="0" multiplier="1.0" name="load.on" oid="1.3.6.1.2.1.33.1.8.3.0"/>
-		<snmp_info default="" multiplier="8.0" name="ups.timer.reboot" oid="1.3.6.1.2.1.33.1.8.4.0" power_status="yes" string="yes" writable="yes"/>
-		<snmp_info default="" lookup="ietf_yes_no_info" multiplier="128.0" name="ups.start.auto" oid="1.3.6.1.2.1.33.1.8.5.0" power_status="yes" string="yes"/>
-		<snmp_info default="" multiplier="1.0" name="input.voltage.nominal" oid="1.3.6.1.2.1.33.1.9.1.0" power_status="yes"/>
-		<snmp_info default="" multiplier="0.1" name="input.frequency.nominal" oid="1.3.6.1.2.1.33.1.9.2.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="output.voltage.nominal" oid="1.3.6.1.2.1.33.1.9.3.0" power_status="yes"/>
-		<snmp_info default="" multiplier="0.1" name="output.frequency.nominal" oid="1.3.6.1.2.1.33.1.9.4.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="output.power.nominal" oid="1.3.6.1.2.1.33.1.9.5.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="output.realpower.nominal" oid="1.3.6.1.2.1.33.1.9.6.0" power_status="yes"/>
-		<snmp_info default="" multiplier="60.0" name="battery.runtime.low" oid="1.3.6.1.2.1.33.1.9.7.0" power_status="yes"/>
-		<snmp_info default="" lookup="ietf_beeper_status_info" multiplier="128.0" name="ups.beeper.status" oid="1.3.6.1.2.1.33.1.9.8.0" power_status="yes" string="yes"/>
+		<snmp_info default="" multiplier="8.0" name="ups.timer.reboot" oid="1.3.6.1.2.1.33.1.8.4.0" string="yes" writable="yes"/>
+		<snmp_info default="" lookup="ietf_yes_no_info" multiplier="128.0" name="ups.start.auto" oid="1.3.6.1.2.1.33.1.8.5.0" string="yes"/>
+		<snmp_info default="" multiplier="1.0" name="input.voltage.nominal" oid="1.3.6.1.2.1.33.1.9.1.0"/>
+		<snmp_info default="" multiplier="0.1" name="input.frequency.nominal" oid="1.3.6.1.2.1.33.1.9.2.0"/>
+		<snmp_info default="" multiplier="1.0" name="output.voltage.nominal" oid="1.3.6.1.2.1.33.1.9.3.0"/>
+		<snmp_info default="" multiplier="0.1" name="output.frequency.nominal" oid="1.3.6.1.2.1.33.1.9.4.0"/>
+		<snmp_info default="" multiplier="1.0" name="output.power.nominal" oid="1.3.6.1.2.1.33.1.9.5.0"/>
+		<snmp_info default="" multiplier="1.0" name="output.realpower.nominal" oid="1.3.6.1.2.1.33.1.9.6.0"/>
+		<snmp_info default="" multiplier="60.0" name="battery.runtime.low" oid="1.3.6.1.2.1.33.1.9.7.0"/>
+		<snmp_info default="" lookup="ietf_beeper_status_info" multiplier="128.0" name="ups.beeper.status" oid="1.3.6.1.2.1.33.1.9.8.0" string="yes"/>
 		<snmp_info command="yes" default="1" multiplier="1.0" name="beeper.disable" oid="1.3.6.1.2.1.33.1.9.8.0"/>
 		<snmp_info command="yes" default="2" multiplier="1.0" name="beeper.enable" oid="1.3.6.1.2.1.33.1.9.8.0"/>
 		<snmp_info command="yes" default="3" multiplier="1.0" name="beeper.mute" oid="1.3.6.1.2.1.33.1.9.8.0"/>
-		<snmp_info default="" multiplier="1.0" name="input.transfer.low" oid="1.3.6.1.2.1.33.1.9.9.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="input.transfer.high" oid="1.3.6.1.2.1.33.1.9.10.0" power_status="yes"/>
+		<snmp_info default="" multiplier="1.0" name="input.transfer.low" oid="1.3.6.1.2.1.33.1.9.9.0"/>
+		<snmp_info default="" multiplier="1.0" name="input.transfer.high" oid="1.3.6.1.2.1.33.1.9.10.0"/>
 	</snmp>
 	<mib2nut auto_check="1.3.6.1.2.1.33.1.1.1.0" mib_name="ietf" name="ietf" oid=".1.3.6.1.2.1.33" power_status="1.3.6.1.2.1.33.1.4.1.0" snmp_info="ietf_mib" version="1.52"/>
 	<mib2nut mib_name="tripplite" name="tripplite_ietf" oid=".1.3.6.1.4.1.850.1" snmp_info="ietf_mib" version="1.52"/>

--- a/scripts/DMF/dmfsnmp/mge-mib.dmf
+++ b/scripts/DMF/dmfsnmp/mge-mib.dmf
@@ -78,11 +78,11 @@
 		<snmp_info default="" flag_ok="yes" multiplier="128.0" name="ups.firmware" oid=".1.3.6.1.4.1.705.1.1.4.0" static="yes" string="yes"/>
 		<snmp_info default="" flag_ok="yes" multiplier="128.0" name="ups.firmware.aux" oid=".1.3.6.1.4.1.705.1.12.12.0" static="yes" string="yes"/>
 		<snmp_info default="" multiplier="1.0" name="ups.load" oid=".1.3.6.1.4.1.705.1.7.2.1.4.1" output_1_phase="yes"/>
-		<snmp_info default="" lookup="mge_beeper_status_info" multiplier="128.0" name="ups.beeper.status" oid="1.3.6.1.2.1.33.1.9.8.0" power_status="yes" string="yes"/>
+		<snmp_info default="" lookup="mge_beeper_status_info" multiplier="128.0" name="ups.beeper.status" oid="1.3.6.1.2.1.33.1.9.8.0" string="yes"/>
 		<snmp_info default="" multiplier="1.0" name="ups.L1.load" oid=".1.3.6.1.4.1.705.1.7.2.1.4.1" output_3_phase="yes"/>
 		<snmp_info default="" multiplier="1.0" name="ups.L2.load" oid=".1.3.6.1.4.1.705.1.7.2.1.4.2" output_3_phase="yes"/>
 		<snmp_info default="" multiplier="1.0" name="ups.L3.load" oid=".1.3.6.1.4.1.705.1.7.2.1.4.3" output_3_phase="yes"/>
-		<snmp_info default="" lookup="mge_test_result_info" multiplier="128.0" name="ups.test.result" oid=".1.3.6.1.2.1.33.1.7.3.0" power_status="yes" string="yes"/>
+		<snmp_info default="" lookup="mge_test_result_info" multiplier="128.0" name="ups.test.result" oid=".1.3.6.1.2.1.33.1.7.3.0" string="yes"/>
 		<snmp_info absent="yes" default="20" flag_ok="yes" multiplier="6.0" name="ups.delay.shutdown" oid="1.3.6.1.2.1.33.1.8.2.0" string="yes" writable="yes"/>
 		<snmp_info absent="yes" default="30" flag_ok="yes" multiplier="6.0" name="ups.delay.start" oid="1.3.6.1.2.1.33.1.8.3.0" string="yes" writable="yes"/>
 		<snmp_info default="" flag_ok="yes" multiplier="1.0" name="ups.timer.shutdown" oid="1.3.6.1.2.1.33.1.8.2.0"/>
@@ -99,7 +99,7 @@
 		<snmp_info battery_status="yes" default="" flag_ok="yes" lookup="mge_overload_info" multiplier="128.0" name="ups.status" oid=".1.3.6.1.4.1.705.1.7.10.0" string="yes"/>
 		<snmp_info battery_status="yes" default="" flag_ok="yes" lookup="mge_trim_info" multiplier="128.0" name="ups.status" oid=".1.3.6.1.4.1.705.1.7.12.0" string="yes"/>
 		<snmp_info default="" flag_ok="yes" lookup="mge_power_source_info" multiplier="128.0" name="ups.status" oid=".1.3.6.1.2.1.33.1.4.1.0" power_status="yes" string="yes"/>
-		<snmp_info default="" multiplier="1.0" name="input.phases" oid=".1.3.6.1.4.1.705.1.6.1.0" power_status="yes"/>
+		<snmp_info default="" multiplier="1.0" name="input.phases" oid=".1.3.6.1.4.1.705.1.6.1.0"/>
 		<snmp_info default="" input_1_phase="yes" multiplier="0.1" name="input.voltage" oid=".1.3.6.1.4.1.705.1.6.2.1.2.1"/>
 		<snmp_info default="" input_3_phase="yes" multiplier="0.1" name="input.L1-N.voltage" oid=".1.3.6.1.4.1.705.1.6.2.1.2.1"/>
 		<snmp_info default="" input_3_phase="yes" multiplier="0.1" name="input.L2-N.voltage" oid=".1.3.6.1.4.1.705.1.6.2.1.2.2"/>
@@ -121,7 +121,7 @@
 		<snmp_info default="" input_3_phase="yes" multiplier="0.1" name="input.L2.current" oid=".1.3.6.1.4.1.705.1.6.2.1.6.2"/>
 		<snmp_info default="" input_3_phase="yes" multiplier="0.1" name="input.L3.current" oid=".1.3.6.1.4.1.705.1.6.2.1.6.3"/>
 		<snmp_info default="" flag_ok="yes" lookup="mge_transfer_reason_info" multiplier="128.0" name="input.transfer.reason" oid=".1.3.6.1.4.1.705.1.6.4.0" string="yes"/>
-		<snmp_info default="" multiplier="1.0" name="output.phases" oid=".1.3.6.1.4.1.705.1.7.1.0" power_status="yes"/>
+		<snmp_info default="" multiplier="1.0" name="output.phases" oid=".1.3.6.1.4.1.705.1.7.1.0"/>
 		<snmp_info default="" multiplier="0.1" name="output.voltage" oid=".1.3.6.1.4.1.705.1.7.2.1.2.1" output_1_phase="yes"/>
 		<snmp_info default="" multiplier="0.1" name="output.L1-N.voltage" oid=".1.3.6.1.4.1.705.1.7.2.1.2.1" output_3_phase="yes"/>
 		<snmp_info default="" multiplier="0.1" name="output.L2-N.voltage" oid=".1.3.6.1.4.1.705.1.7.2.1.2.2" output_3_phase="yes"/>
@@ -137,12 +137,12 @@
 		<snmp_info default="" flag_ok="yes" multiplier="1.0" name="battery.charge" oid=".1.3.6.1.4.1.705.1.5.2.0"/>
 		<snmp_info default="" flag_ok="yes" multiplier="1.0" name="battery.runtime" oid=".1.3.6.1.4.1.705.1.5.1.0"/>
 		<snmp_info default="" flag_ok="yes" multiplier="1.0" name="battery.runtime.low" oid=".1.3.6.1.4.1.705.1.4.7.0"/>
-		<snmp_info default="" flag_ok="yes" multiplier="2.0" name="battery.charge.low" oid=".1.3.6.1.4.1.705.1.4.8.0" power_status="yes" string="yes" writable="yes"/>
+		<snmp_info default="" flag_ok="yes" int_val="yes" multiplier="2.0" name="battery.charge.low" oid=".1.3.6.1.4.1.705.1.4.8.0" string="yes" writable="yes"/>
 		<snmp_info default="" flag_ok="yes" multiplier="0.1" name="battery.voltage" oid=".1.3.6.1.4.1.705.1.5.5.0"/>
-		<snmp_info default="" flag_ok="yes" multiplier="0.1" name="ambient.temperature" oid=".1.3.6.1.4.1.705.1.8.1.0" power_status="yes"/>
-		<snmp_info default="" flag_ok="yes" multiplier="0.1" name="ambient.humidity" oid=".1.3.6.1.4.1.705.1.8.2.0" power_status="yes"/>
-		<snmp_info default="" flag_ok="yes" lookup="mge_ambient_drycontacts_info" multiplier="128.0" name="ambient.contacts.1.status" oid=".1.3.6.1.4.1.705.1.8.7.1.9.1" power_status="yes" string="yes"/>
-		<snmp_info default="" flag_ok="yes" lookup="mge_ambient_drycontacts_info" multiplier="128.0" name="ambient.contacts.2.status" oid=".1.3.6.1.4.1.705.1.8.7.1.10.1" power_status="yes" string="yes"/>
+		<snmp_info default="" flag_ok="yes" int_val="yes" multiplier="0.1" name="ambient.temperature" oid=".1.3.6.1.4.1.705.1.8.1.0"/>
+		<snmp_info default="" flag_ok="yes" int_val="yes" multiplier="0.1" name="ambient.humidity" oid=".1.3.6.1.4.1.705.1.8.2.0"/>
+		<snmp_info default="" flag_ok="yes" int_val="yes" lookup="mge_ambient_drycontacts_info" multiplier="128.0" name="ambient.contacts.1.status" oid=".1.3.6.1.4.1.705.1.8.7.1.9.1" string="yes"/>
+		<snmp_info default="" flag_ok="yes" int_val="yes" lookup="mge_ambient_drycontacts_info" multiplier="128.0" name="ambient.contacts.2.status" oid=".1.3.6.1.4.1.705.1.8.7.1.10.1" string="yes"/>
 		<snmp_info absent="yes" default="0" flag_ok="yes" multiplier="1.0" name="outlet.id" static="yes"/>
 		<snmp_info absent="yes" default="Main Outlet" flag_ok="yes" multiplier="20.0" name="outlet.desc" static="yes" string="yes" writable="yes"/>
 		<snmp_info command="yes" default="2" flag_ok="yes" multiplier="1.0" name="test.battery.start" oid=".1.3.6.1.4.1.705.1.10.4.0"/>

--- a/scripts/DMF/dmfsnmp/netvision-mib.dmf
+++ b/scripts/DMF/dmfsnmp/netvision-mib.dmf
@@ -34,7 +34,7 @@
 		<snmp_info default="" flag_ok="yes" lookup="netvision_output_info" multiplier="128.0" name="ups.status" oid=".1.3.6.1.4.1.4555.1.1.1.1.4.1.0" power_status="yes" string="yes"/>
 		<snmp_info default="" flag_ok="yes" lookup="netvision_onbatt_info" multiplier="128.0" name="ups.status" oid=".1.3.6.1.4.1.4555.1.1.1.1.6.3.2.0" power_status="yes" string="yes"/>
 		<snmp_info input_1_phase="yes" multiplier="1.0" name="ups.load" oid=".1.3.6.1.4.1.4555.1.1.1.1.4.4.1.4.1"/>
-		<snmp_info multiplier="1.0" name="input.phases" oid=".1.3.6.1.4.1.4555.1.1.1.1.3.1.0" power_status="yes"/>
+		<snmp_info multiplier="1.0" name="input.phases" oid=".1.3.6.1.4.1.4555.1.1.1.1.3.1.0"/>
 		<snmp_info flag_ok="yes" multiplier="0.1" name="input.frequency" oid=".1.3.6.1.4.1.4555.1.1.1.1.3.2.0"/>
 		<snmp_info input_1_phase="yes" multiplier="0.1" name="input.voltage" oid=".1.3.6.1.4.1.4555.1.1.1.1.3.3.1.5.1"/>
 		<snmp_info input_1_phase="yes" multiplier="0.1" name="input.current" oid=".1.3.6.1.4.1.4555.1.1.1.1.3.3.1.3.1"/>
@@ -44,7 +44,7 @@
 		<snmp_info input_3_phase="yes" multiplier="0.1" name="input.L2.current" oid=".1.3.6.1.4.1.4555.1.1.1.1.3.3.1.3.2"/>
 		<snmp_info input_3_phase="yes" multiplier="0.1" name="input.L3-N.voltage" oid=".1.3.6.1.4.1.4555.1.1.1.1.3.3.1.5.3"/>
 		<snmp_info input_3_phase="yes" multiplier="0.1" name="input.L3.current" oid=".1.3.6.1.4.1.4555.1.1.1.1.3.3.1.3.3"/>
-		<snmp_info multiplier="1.0" name="output.phases" oid=".1.3.6.1.4.1.4555.1.1.1.1.4.3.0" power_status="yes"/>
+		<snmp_info multiplier="1.0" name="output.phases" oid=".1.3.6.1.4.1.4555.1.1.1.1.4.3.0"/>
 		<snmp_info flag_ok="yes" multiplier="0.1" name="output.frequency" oid=".1.3.6.1.4.1.4555.1.1.1.1.4.2.0"/>
 		<snmp_info multiplier="0.1" name="output.voltage" oid=".1.3.6.1.4.1.4555.1.1.1.1.4.4.1.2.1" output_1_phase="yes"/>
 		<snmp_info multiplier="0.1" name="output.current" oid=".1.3.6.1.4.1.4555.1.1.1.1.4.4.1.3.1" output_1_phase="yes"/>
@@ -58,7 +58,7 @@
 		<snmp_info multiplier="0.1" name="output.L3-N.voltage" oid=".1.3.6.1.4.1.4555.1.1.1.1.4.4.1.2.3" output_3_phase="yes"/>
 		<snmp_info multiplier="0.1" name="output.L3.current" oid=".1.3.6.1.4.1.4555.1.1.1.1.4.4.1.3.3" output_3_phase="yes"/>
 		<snmp_info multiplier="1.0" name="output.L3.power.percent" oid=".1.3.6.1.4.1.4555.1.1.1.1.4.4.1.4.3" output_3_phase="yes"/>
-		<snmp_info multiplier="1.0" name="input.bypass.phases" oid=".1.3.6.1.4.1.4555.1.1.1.1.5.2.0" power_status="yes"/>
+		<snmp_info multiplier="1.0" name="input.bypass.phases" oid=".1.3.6.1.4.1.4555.1.1.1.1.5.2.0"/>
 		<snmp_info flag_ok="yes" multiplier="0.1" name="input.bypass.frequency" oid=".1.3.6.1.4.1.4555.1.1.1.1.5.1.0"/>
 		<snmp_info bypass_1_phase="yes" multiplier="0.1" name="input.bypass.voltage" oid=".1.3.6.1.4.1.4555.1.1.1.1.5.3.1.2.1"/>
 		<snmp_info bypass_1_phase="yes" multiplier="0.1" name="input.bypass.current" oid=".1.3.6.1.4.1.4555.1.1.1.1.5.3.1.3.1"/>

--- a/scripts/DMF/dmfsnmp/powerware-mib.dmf
+++ b/scripts/DMF/dmfsnmp/powerware-mib.dmf
@@ -173,7 +173,7 @@
 		<snmp_info default="" multiplier="128.0" name="ups.firmware" oid="1.3.6.1.4.1.534.1.1.3.0" string="yes"/>
 		<snmp_info default="" multiplier="128.0" name="ups.firmware.aux" oid="1.3.6.1.2.1.33.1.1.4.0" string="yes"/>
 		<snmp_info default="" multiplier="128.0" name="ups.serial" oid="1.3.6.1.2.1.33.1.1.5.0" static="yes" string="yes"/>
-		<snmp_info default="" multiplier="1.0" name="ups.load" oid="1.3.6.1.4.1.534.1.4.1.0" output_1_phase="yes"/>
+		<snmp_info default="" multiplier="1.0" name="ups.load" oid="1.3.6.1.4.1.534.1.4.1.0"/>
 		<snmp_info default="" multiplier="1.0" name="ups.power" oid="1.3.6.1.4.1.534.1.4.4.1.4.1"/>
 		<snmp_info default="" multiplier="1.0" name="ups.power" oid="1.3.6.1.4.1.534.1.4.4.1.4.1.0"/>
 		<snmp_info default="OFF" lookup="pw_pwr_info" multiplier="128.0" name="ups.status" oid="1.3.6.1.4.1.534.1.4.5.0" power_status="yes" string="yes"/>
@@ -302,7 +302,7 @@
 		<snmp_info command="yes" multiplier="1.0" name="outlet.%i.load.on.delay" oid=".1.3.6.1.4.1.534.1.12.2.1.4.%i" outlet="yes"/>
 		<snmp_info default="" multiplier="1.0" name="ups.alarms" oid="1.3.6.1.4.1.534.1.7.1.0"/>
 	</snmp>
-	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pw" name="powerware" oid=".1.3.6.1.4.1.534.1" snmp_info="pw_mib" version="0.99"/>
-	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pxgx_ups" name="pxgx_ups" oid=".1.3.6.1.4.1.534.2.12" snmp_info="pw_mib" version="0.99"/>
+	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pw" name="powerware" oid=".1.3.6.1.4.1.534.1" snmp_info="pw_mib" version="1.00"/>
+	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pxgx_ups" name="pxgx_ups" oid=".1.3.6.1.4.1.534.2.12" snmp_info="pw_mib" version="1.00"/>
 </nut>
 

--- a/scripts/DMF/dmfsnmp/powerware-mib.dmf
+++ b/scripts/DMF/dmfsnmp/powerware-mib.dmf
@@ -170,44 +170,44 @@
 	<snmp name="pw_mib">
 		<snmp_info default="" multiplier="128.0" name="ups.mfr" oid="1.3.6.1.4.1.534.1.1.1.0" static="yes" string="yes"/>
 		<snmp_info default="" multiplier="128.0" name="ups.model" oid="1.3.6.1.4.1.534.1.1.2.0" static="yes" string="yes"/>
-		<snmp_info default="" multiplier="128.0" name="ups.firmware" oid="1.3.6.1.4.1.534.1.1.3.0" power_status="yes" string="yes"/>
-		<snmp_info default="" multiplier="128.0" name="ups.firmware.aux" oid="1.3.6.1.2.1.33.1.1.4.0" power_status="yes" string="yes"/>
+		<snmp_info default="" multiplier="128.0" name="ups.firmware" oid="1.3.6.1.4.1.534.1.1.3.0" string="yes"/>
+		<snmp_info default="" multiplier="128.0" name="ups.firmware.aux" oid="1.3.6.1.2.1.33.1.1.4.0" string="yes"/>
 		<snmp_info default="" multiplier="128.0" name="ups.serial" oid="1.3.6.1.2.1.33.1.1.5.0" static="yes" string="yes"/>
 		<snmp_info default="" multiplier="1.0" name="ups.load" oid="1.3.6.1.4.1.534.1.4.1.0" output_1_phase="yes"/>
-		<snmp_info default="" multiplier="1.0" name="ups.power" oid="1.3.6.1.4.1.534.1.4.4.1.4.1" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="ups.power" oid="1.3.6.1.4.1.534.1.4.4.1.4.1.0" power_status="yes"/>
+		<snmp_info default="" multiplier="1.0" name="ups.power" oid="1.3.6.1.4.1.534.1.4.4.1.4.1"/>
+		<snmp_info default="" multiplier="1.0" name="ups.power" oid="1.3.6.1.4.1.534.1.4.4.1.4.1.0"/>
 		<snmp_info default="OFF" lookup="pw_pwr_info" multiplier="128.0" name="ups.status" oid="1.3.6.1.4.1.534.1.4.5.0" power_status="yes" string="yes"/>
 		<snmp_info battery_status="yes" default="" lookup="pw_alarm_ob" multiplier="128.0" name="ups.status" oid="1.3.6.1.4.1.534.1.7.3" string="yes"/>
 		<snmp_info battery_status="yes" default="" lookup="pw_alarm_lb" multiplier="128.0" name="ups.status" oid="1.3.6.1.4.1.534.1.7.4" string="yes"/>
 		<snmp_info battery_status="yes" default="" lookup="pw_battery_abm_status" multiplier="128.0" name="ups.status" oid="1.3.6.1.4.1.534.1.2.5.0" string="yes"/>
 		<snmp_info default="" flag_ok="yes" lookup="pw_topology_info" multiplier="128.0" name="ups.type" oid="1.3.6.1.4.1.534.1.13.1.0" static="yes" string="yes"/>
-		<snmp_info default="" multiplier="1.0" name="ups.realpower.nominal" oid="1.3.6.1.4.1.534.1.10.3.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="ups.power.nominal" oid="1.3.6.1.2.1.33.1.9.5.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="ups.temperature" oid="1.3.6.1.4.1.534.1.6.1.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="ups.temperature.low" oid="1.3.6.1.4.1.534.1.6.2.0" power_status="yes" writable="yes"/>
-		<snmp_info default="" multiplier="1.0" name="ups.temperature.high" oid="1.3.6.1.4.1.534.1.6.3.0" power_status="yes" writable="yes"/>
-		<snmp_info default="" lookup="pw_batt_test_info" multiplier="128.0" name="ups.test.result" oid="1.3.6.1.4.1.534.1.8.2.0" power_status="yes" string="yes"/>
+		<snmp_info default="" multiplier="1.0" name="ups.realpower.nominal" oid="1.3.6.1.4.1.534.1.10.3.0"/>
+		<snmp_info default="" multiplier="1.0" name="ups.power.nominal" oid="1.3.6.1.2.1.33.1.9.5.0"/>
+		<snmp_info default="" multiplier="1.0" name="ups.temperature" oid="1.3.6.1.4.1.534.1.6.1.0"/>
+		<snmp_info default="" multiplier="1.0" name="ups.temperature.low" oid="1.3.6.1.4.1.534.1.6.2.0" writable="yes"/>
+		<snmp_info default="" multiplier="1.0" name="ups.temperature.high" oid="1.3.6.1.4.1.534.1.6.3.0" writable="yes"/>
+		<snmp_info default="" lookup="pw_batt_test_info" multiplier="128.0" name="ups.test.result" oid="1.3.6.1.4.1.534.1.8.2.0" string="yes"/>
 		<snmp_info default="" flag_ok="yes" lookup="pw_yes_no_info" multiplier="128.0" name="ups.start.auto" oid="1.3.6.1.2.1.33.1.8.5.0" string="yes" writable="yes"/>
 		<snmp_info battery_status="yes" default="" lookup="pw_abm_status_info" multiplier="128.0" name="battery.charger.status" oid="1.3.6.1.4.1.534.1.2.5.0" string="yes"/>
-		<snmp_info default="" multiplier="1.0" name="battery.charge" oid="1.3.6.1.4.1.534.1.2.4.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="battery.runtime" oid="1.3.6.1.4.1.534.1.2.1.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="battery.voltage" oid="1.3.6.1.4.1.534.1.2.2.0" power_status="yes"/>
-		<snmp_info default="" multiplier="0.1" name="battery.current" oid="1.3.6.1.4.1.534.1.2.3.0" power_status="yes"/>
-		<snmp_info default="" multiplier="60.0" name="battery.runtime.low" oid="1.3.6.1.2.1.33.1.9.7.0" power_status="yes"/>
+		<snmp_info default="" multiplier="1.0" name="battery.charge" oid="1.3.6.1.4.1.534.1.2.4.0"/>
+		<snmp_info default="" multiplier="1.0" name="battery.runtime" oid="1.3.6.1.4.1.534.1.2.1.0"/>
+		<snmp_info default="" multiplier="1.0" name="battery.voltage" oid="1.3.6.1.4.1.534.1.2.2.0"/>
+		<snmp_info default="" multiplier="0.1" name="battery.current" oid="1.3.6.1.4.1.534.1.2.3.0"/>
+		<snmp_info default="" multiplier="60.0" name="battery.runtime.low" oid="1.3.6.1.2.1.33.1.9.7.0"/>
 		<snmp_info flag_ok="yes" lookup="su_convert_to_iso_date_info" multiplier="128.0" name="battery.date" oid=".1.3.6.1.4.1.534.1.2.6.0" string="yes" writable="yes"/>
-		<snmp_info default="" multiplier="1.0" name="output.phases" oid="1.3.6.1.4.1.534.1.4.3.0" power_status="yes"/>
-		<snmp_info default="" multiplier="0.1" name="output.frequency" oid="1.3.6.1.4.1.534.1.4.2.0" power_status="yes"/>
-		<snmp_info default="" multiplier="0.1" name="output.frequency.nominal" oid="1.3.6.1.4.1.534.1.10.4.0" power_status="yes"/>
+		<snmp_info default="" multiplier="1.0" name="output.phases" oid="1.3.6.1.4.1.534.1.4.3.0"/>
+		<snmp_info default="" multiplier="0.1" name="output.frequency" oid="1.3.6.1.4.1.534.1.4.2.0"/>
+		<snmp_info default="" multiplier="0.1" name="output.frequency.nominal" oid="1.3.6.1.4.1.534.1.10.4.0"/>
 		<snmp_info default="" multiplier="1.0" name="output.voltage" oid="1.3.6.1.4.1.534.1.4.4.1.2.1" output_1_phase="yes"/>
 		<snmp_info default="" multiplier="1.0" name="output.voltage" oid="1.3.6.1.4.1.534.1.4.4.1.2.1.0" output_1_phase="yes"/>
-		<snmp_info default="" multiplier="1.0" name="output.voltage.nominal" oid="1.3.6.1.4.1.534.1.10.1.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="output.voltage.low" oid=".1.3.6.1.4.1.534.1.10.6.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="output.voltage.high" oid=".1.3.6.1.4.1.534.1.10.7.0" power_status="yes"/>
+		<snmp_info default="" multiplier="1.0" name="output.voltage.nominal" oid="1.3.6.1.4.1.534.1.10.1.0"/>
+		<snmp_info default="" multiplier="1.0" name="output.voltage.low" oid=".1.3.6.1.4.1.534.1.10.6.0"/>
+		<snmp_info default="" multiplier="1.0" name="output.voltage.high" oid=".1.3.6.1.4.1.534.1.10.7.0"/>
 		<snmp_info default="" multiplier="1.0" name="output.current" oid="1.3.6.1.4.1.534.1.4.4.1.3.1" output_1_phase="yes"/>
 		<snmp_info default="" multiplier="1.0" name="output.current" oid="1.3.6.1.4.1.534.1.4.4.1.3.1.0" output_1_phase="yes"/>
 		<snmp_info default="" multiplier="1.0" name="output.realpower" oid="1.3.6.1.4.1.534.1.4.4.1.4.1" output_1_phase="yes"/>
-		<snmp_info default="" multiplier="1.0" name="output.realpower" oid="1.3.6.1.4.1.534.1.4.4.1.4.1.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="output.realpower.nominal" oid="1.3.6.1.4.1.534.1.10.3.0" power_status="yes"/>
+		<snmp_info default="" multiplier="1.0" name="output.realpower" oid="1.3.6.1.4.1.534.1.4.4.1.4.1.0"/>
+		<snmp_info default="" multiplier="1.0" name="output.realpower.nominal" oid="1.3.6.1.4.1.534.1.10.3.0"/>
 		<snmp_info default="" multiplier="1.0" name="output.L1-N.voltage" oid="1.3.6.1.4.1.534.1.4.4.1.2.1" output_3_phase="yes"/>
 		<snmp_info default="" multiplier="1.0" name="output.L2-N.voltage" oid="1.3.6.1.4.1.534.1.4.4.1.2.2" output_3_phase="yes"/>
 		<snmp_info default="" multiplier="1.0" name="output.L3-N.voltage" oid="1.3.6.1.4.1.534.1.4.4.1.2.3" output_3_phase="yes"/>
@@ -220,12 +220,12 @@
 		<snmp_info default="" multiplier="1.0" name="output.L1.power.percent" oid="1.3.6.1.2.1.33.1.4.4.1.5.1" output_3_phase="yes"/>
 		<snmp_info default="" multiplier="1.0" name="output.L2.power.percent" oid="1.3.6.1.2.1.33.1.4.4.1.5.2" output_3_phase="yes"/>
 		<snmp_info default="" multiplier="1.0" name="output.L3.power.percent" oid="1.3.6.1.2.1.33.1.4.4.1.5.3" output_3_phase="yes"/>
-		<snmp_info default="" multiplier="1.0" name="output.voltage.nominal" oid="1.3.6.1.4.1.534.1.10.1.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="input.phases" oid="1.3.6.1.4.1.534.1.3.3.0" power_status="yes"/>
-		<snmp_info default="" multiplier="0.1" name="input.frequency" oid="1.3.6.1.4.1.534.1.3.1.0" power_status="yes"/>
+		<snmp_info default="" multiplier="1.0" name="output.voltage.nominal" oid="1.3.6.1.4.1.534.1.10.1.0"/>
+		<snmp_info default="" multiplier="1.0" name="input.phases" oid="1.3.6.1.4.1.534.1.3.3.0"/>
+		<snmp_info default="" multiplier="0.1" name="input.frequency" oid="1.3.6.1.4.1.534.1.3.1.0"/>
 		<snmp_info default="" input_1_phase="yes" multiplier="1.0" name="input.voltage" oid="1.3.6.1.4.1.534.1.3.4.1.2.0"/>
 		<snmp_info default="" input_1_phase="yes" multiplier="1.0" name="input.voltage" oid="1.3.6.1.4.1.534.1.3.4.1.2.1"/>
-		<snmp_info default="" multiplier="1.0" name="input.voltage.nominal" oid="1.3.6.1.4.1.534.1.10.2.0" power_status="yes"/>
+		<snmp_info default="" multiplier="1.0" name="input.voltage.nominal" oid="1.3.6.1.4.1.534.1.10.2.0"/>
 		<snmp_info default="" input_1_phase="yes" multiplier="0.1" name="input.current" oid="1.3.6.1.4.1.534.1.3.4.1.3.0"/>
 		<snmp_info default="" input_3_phase="yes" multiplier="1.0" name="input.L1-N.voltage" oid="1.3.6.1.4.1.534.1.3.4.1.2.1"/>
 		<snmp_info default="" input_3_phase="yes" multiplier="1.0" name="input.L2-N.voltage" oid="1.3.6.1.4.1.534.1.3.4.1.2.2"/>
@@ -236,8 +236,8 @@
 		<snmp_info default="" input_3_phase="yes" multiplier="1.0" name="input.L1.realpower" oid="1.3.6.1.4.1.534.1.3.4.1.4.1"/>
 		<snmp_info default="" input_3_phase="yes" multiplier="1.0" name="input.L2.realpower" oid="1.3.6.1.4.1.534.1.3.4.1.4.2"/>
 		<snmp_info default="" input_3_phase="yes" multiplier="1.0" name="input.L3.realpower" oid="1.3.6.1.4.1.534.1.3.4.1.4.3"/>
-		<snmp_info default="" multiplier="1.0" name="input.quality" oid="1.3.6.1.4.1.534.1.3.2.0" power_status="yes"/>
-		<snmp_info default="" multiplier="0.1" name="input.bypass.frequency" oid="1.3.6.1.4.1.534.1.5.1.0" power_status="yes"/>
+		<snmp_info default="" multiplier="1.0" name="input.quality" oid="1.3.6.1.4.1.534.1.3.2.0"/>
+		<snmp_info default="" multiplier="0.1" name="input.bypass.frequency" oid="1.3.6.1.4.1.534.1.5.1.0"/>
 		<snmp_info default="" input_1_phase="yes" multiplier="1.0" name="input.bypass.voltage" oid="1.3.6.1.4.1.534.1.5.3.1.2.0"/>
 		<snmp_info default="" input_1_phase="yes" multiplier="1.0" name="input.bypass.voltage" oid="1.3.6.1.4.1.534.1.5.3.1.2.1.0"/>
 		<snmp_info default="" input_3_phase="yes" multiplier="1.0" name="input.bypass.L1-N.voltage" oid="1.3.6.1.4.1.534.1.5.3.1.2.1"/>
@@ -249,17 +249,17 @@
 		<snmp_info multiplier="1.0" name="outlet.%i.id" oid=".1.3.6.1.4.1.534.1.12.2.1.1.%i" outlet="yes" static="yes"/>
 		<snmp_info multiplier="1.0" name="outlet.%i.switchable" oid=".1.3.6.1.4.1.534.1.12.2.1.1.%i" outlet="yes" static="yes"/>
 		<snmp_info lookup="pw_outlet_status_info" multiplier="1.0" name="outlet.%i.status" oid=".1.3.6.1.4.1.534.1.12.2.1.2.%i" outlet="yes"/>
-		<snmp_info default="" multiplier="1.0" name="ambient.temperature" oid="1.3.6.1.4.1.534.1.6.5.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="ambient.temperature.low" oid="1.3.6.1.4.1.534.1.6.9.0" power_status="yes" writable="yes"/>
-		<snmp_info default="" multiplier="1.0" name="ambient.temperature.high" oid="1.3.6.1.4.1.534.1.6.10.0" power_status="yes" writable="yes"/>
-		<snmp_info default="" multiplier="1.0" name="ambient.humidity" oid="1.3.6.1.4.1.534.1.6.6.0" power_status="yes"/>
-		<snmp_info default="" multiplier="1.0" name="ambient.humidity.low" oid="1.3.6.1.4.1.534.1.6.11.0" power_status="yes" writable="yes"/>
-		<snmp_info default="" multiplier="1.0" name="ambient.humidity.high" oid="1.3.6.1.4.1.534.1.6.12.0" power_status="yes" writable="yes"/>
-		<snmp_info default="" multiplier="1.0" name="ambient.contacts.1.name" oid=".1.3.6.1.4.1.534.1.6.8.1.4.1" power_status="yes" string="yes"/>
-		<snmp_info default="" multiplier="1.0" name="ambient.contacts.2.name" oid=".1.3.6.1.4.1.534.1.6.8.1.4.2" power_status="yes" string="yes"/>
-		<snmp_info default="" lookup="pw_ambient_drycontacts_info" multiplier="1.0" name="ambient.contacts.1.status" oid=".1.3.6.1.4.1.534.1.6.8.1.3.1" power_status="yes" string="yes"/>
-		<snmp_info default="" lookup="pw_ambient_drycontacts_info" multiplier="1.0" name="ambient.contacts.2.status" oid=".1.3.6.1.4.1.534.1.6.8.1.3.2" power_status="yes" string="yes"/>
-		<snmp_info default="" multiplier="1.0" name="ambient.count" oid=".1.3.6.1.4.1.534.6.8.1.1.1.0" power_status="yes" writable="yes"/>
+		<snmp_info default="" multiplier="1.0" name="ambient.temperature" oid="1.3.6.1.4.1.534.1.6.5.0"/>
+		<snmp_info default="" multiplier="1.0" name="ambient.temperature.low" oid="1.3.6.1.4.1.534.1.6.9.0" writable="yes"/>
+		<snmp_info default="" multiplier="1.0" name="ambient.temperature.high" oid="1.3.6.1.4.1.534.1.6.10.0" writable="yes"/>
+		<snmp_info default="" multiplier="1.0" name="ambient.humidity" oid="1.3.6.1.4.1.534.1.6.6.0"/>
+		<snmp_info default="" multiplier="1.0" name="ambient.humidity.low" oid="1.3.6.1.4.1.534.1.6.11.0" writable="yes"/>
+		<snmp_info default="" multiplier="1.0" name="ambient.humidity.high" oid="1.3.6.1.4.1.534.1.6.12.0" writable="yes"/>
+		<snmp_info default="" multiplier="1.0" name="ambient.contacts.1.name" oid=".1.3.6.1.4.1.534.1.6.8.1.4.1" string="yes"/>
+		<snmp_info default="" multiplier="1.0" name="ambient.contacts.2.name" oid=".1.3.6.1.4.1.534.1.6.8.1.4.2" string="yes"/>
+		<snmp_info default="" lookup="pw_ambient_drycontacts_info" multiplier="1.0" name="ambient.contacts.1.status" oid=".1.3.6.1.4.1.534.1.6.8.1.3.1" string="yes"/>
+		<snmp_info default="" lookup="pw_ambient_drycontacts_info" multiplier="1.0" name="ambient.contacts.2.status" oid=".1.3.6.1.4.1.534.1.6.8.1.3.2" string="yes"/>
+		<snmp_info default="" multiplier="1.0" name="ambient.count" oid=".1.3.6.1.4.1.534.6.8.1.1.1.0" writable="yes"/>
 		<snmp_info ambient="yes" lookup="pw_emp002_ambient_presence_info" multiplier="128.0" name="ambient.%i.present" oid=".1.3.6.1.4.1.534.6.8.1.1.4.1.1.%i" string="yes"/>
 		<snmp_info ambient="yes" default="" multiplier="1.0" name="ambient.%i.name" oid=".1.3.6.1.4.1.534.6.8.1.1.3.1.1.%i" string="yes"/>
 		<snmp_info ambient="yes" default="" multiplier="1.0" name="ambient.%i.mfr" oid=".1.3.6.1.4.1.534.6.8.1.1.2.1.6.%i" string="yes"/>
@@ -300,7 +300,7 @@
 		<snmp_info command="yes" default="0" multiplier="1.0" name="outlet.%i.load.on" oid=".1.3.6.1.4.1.534.1.12.2.1.4.%i" outlet="yes"/>
 		<snmp_info command="yes" multiplier="1.0" name="outlet.%i.load.off.delay" oid=".1.3.6.1.4.1.534.1.12.2.1.3.%i" outlet="yes"/>
 		<snmp_info command="yes" multiplier="1.0" name="outlet.%i.load.on.delay" oid=".1.3.6.1.4.1.534.1.12.2.1.4.%i" outlet="yes"/>
-		<snmp_info default="" multiplier="1.0" name="ups.alarms" oid="1.3.6.1.4.1.534.1.7.1.0" power_status="yes"/>
+		<snmp_info default="" multiplier="1.0" name="ups.alarms" oid="1.3.6.1.4.1.534.1.7.1.0"/>
 	</snmp>
 	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pw" name="powerware" oid=".1.3.6.1.4.1.534.1" snmp_info="pw_mib" version="0.99"/>
 	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pxgx_ups" name="pxgx_ups" oid=".1.3.6.1.4.1.534.2.12" snmp_info="pw_mib" version="0.99"/>

--- a/scripts/DMF/dmfsnmp/raritan-pdu-mib.dmf
+++ b/scripts/DMF/dmfsnmp/raritan-pdu-mib.dmf
@@ -21,14 +21,14 @@
 		<snmp_info default="" flag_ok="yes" multiplier="128.0" name="ups.serial" oid=".1.3.6.1.4.1.13742.1.1.2.0" static="yes" string="yes"/>
 		<snmp_info default="" flag_ok="yes" multiplier="128.0" name="ups.firmware" oid=".1.3.6.1.4.1.13742.1.1.1.0" static="yes" string="yes"/>
 		<snmp_info absent="yes" default="pdu" flag_ok="yes" multiplier="128.0" name="ups.type" static="yes" string="yes"/>
-		<snmp_info multiplier="1.0" name="ups.temperature" oid=".1.3.6.1.4.1.13742.1.3.1.5.0" power_status="yes"/>
+		<snmp_info multiplier="1.0" name="ups.temperature" oid=".1.3.6.1.4.1.13742.1.3.1.5.0"/>
 		<snmp_info absent="yes" default="0" flag_ok="yes" multiplier="1.0" name="outlet.id" static="yes"/>
 		<snmp_info absent="yes" default="All outlets" flag_ok="yes" multiplier="20.0" name="outlet.desc" static="yes" string="yes" writable="yes"/>
-		<snmp_info default="0" multiplier="1.0" name="outlet.count" oid=".1.3.6.1.4.1.13742.1.2.1.0" power_status="yes"/>
-		<snmp_info multiplier="0.001" name="outlet.current" oid=".1.3.6.1.4.1.13742.1.3.1.1.0" power_status="yes"/>
-		<snmp_info multiplier="0.001" name="outlet.voltage" oid=".1.3.6.1.4.1.13742.1.3.1.2.0" power_status="yes"/>
-		<snmp_info multiplier="1.0" name="outlet.realpower" oid=".1.3.6.1.4.1.13742.1.3.1.3.0" power_status="yes"/>
-		<snmp_info multiplier="1.0" name="outlet.power" oid=".1.3.6.1.4.1.13742.1.3.1.4.0" power_status="yes"/>
+		<snmp_info default="0" multiplier="1.0" name="outlet.count" oid=".1.3.6.1.4.1.13742.1.2.1.0"/>
+		<snmp_info multiplier="0.001" name="outlet.current" oid=".1.3.6.1.4.1.13742.1.3.1.1.0"/>
+		<snmp_info multiplier="0.001" name="outlet.voltage" oid=".1.3.6.1.4.1.13742.1.3.1.2.0"/>
+		<snmp_info multiplier="1.0" name="outlet.realpower" oid=".1.3.6.1.4.1.13742.1.3.1.3.0"/>
+		<snmp_info multiplier="1.0" name="outlet.power" oid=".1.3.6.1.4.1.13742.1.3.1.4.0"/>
 		<snmp_info default="yes" multiplier="1.0" name="outlet.%i.switchable" oid=".1.3.6.1.4.1.13742.1.2.2.1.1.%i" outlet="yes" static="yes"/>
 		<snmp_info absent="yes" default="%i" flag_ok="yes" multiplier="1.0" name="outlet.%i.id" outlet="yes" static="yes"/>
 		<snmp_info multiplier="128.0" name="outlet.%i.desc" oid=".1.3.6.1.4.1.13742.1.2.2.1.2.%i" outlet="yes" string="yes" writable="yes"/>

--- a/scripts/DMF/dmfsnmp/xppc-mib.dmf
+++ b/scripts/DMF/dmfsnmp/xppc-mib.dmf
@@ -22,14 +22,14 @@
 	<snmp name="xppc_mib">
 		<snmp_info absent="yes" default="Tripp Lite / Phoenixtec" flag_ok="yes" multiplier="128.0" name="ups.mfr" static="yes" string="yes"/>
 		<snmp_info default="Generic Phoenixtec SNMP device" flag_ok="yes" multiplier="128.0" name="ups.model" oid=".1.3.6.1.4.1.935.1.1.1.1.1.1.0" string="yes"/>
-		<snmp_info battery_status="yes" default="" flag_ok="yes" lookup="xpcc_onbatt_info" multiplier="128.0" name="ups.status" oid=".1.3.6.1.4.1.935.1.1.1.2.1.1.0" power_status="yes" string="yes"/>
-		<snmp_info flag_ok="yes" multiplier="1.0" name="battery.charge" oid=".1.3.6.1.4.1.935.1.1.1.2.2.1.0" power_status="yes"/>
-		<snmp_info flag_ok="yes" multiplier="0.1" name="ups.temperature" oid=".1.3.6.1.4.1.935.1.1.1.2.2.3.0" power_status="yes"/>
-		<snmp_info flag_ok="yes" multiplier="0.1" name="input.voltage" oid=".1.3.6.1.4.1.935.1.1.1.3.2.1.0" power_status="yes"/>
-		<snmp_info default="" lookup="xpcc_power_info" multiplier="128.0" name="ups.status" oid=".1.3.6.1.4.1.935.1.1.1.4.1.1.0" power_status="yes" string="yes"/>
-		<snmp_info flag_ok="yes" multiplier="0.1" name="output.voltage" oid=".1.3.6.1.4.1.935.1.1.1.4.2.1.0" power_status="yes"/>
-		<snmp_info flag_ok="yes" multiplier="0.1" name="output.frequency" oid=".1.3.6.1.4.1.935.1.1.1.4.2.2.0" power_status="yes"/>
-		<snmp_info flag_ok="yes" multiplier="1.0" name="ups.load" oid=".1.3.6.1.4.1.935.1.1.1.4.2.3.0" power_status="yes"/>
+		<snmp_info battery_status="yes" default="" flag_ok="yes" int_val="yes" lookup="xpcc_onbatt_info" multiplier="128.0" name="ups.status" oid=".1.3.6.1.4.1.935.1.1.1.2.1.1.0" string="yes"/>
+		<snmp_info flag_ok="yes" int_val="yes" multiplier="1.0" name="battery.charge" oid=".1.3.6.1.4.1.935.1.1.1.2.2.1.0"/>
+		<snmp_info flag_ok="yes" int_val="yes" multiplier="0.1" name="ups.temperature" oid=".1.3.6.1.4.1.935.1.1.1.2.2.3.0"/>
+		<snmp_info flag_ok="yes" int_val="yes" multiplier="0.1" name="input.voltage" oid=".1.3.6.1.4.1.935.1.1.1.3.2.1.0"/>
+		<snmp_info default="" int_val="yes" lookup="xpcc_power_info" multiplier="128.0" name="ups.status" oid=".1.3.6.1.4.1.935.1.1.1.4.1.1.0" power_status="yes" string="yes"/>
+		<snmp_info flag_ok="yes" int_val="yes" multiplier="0.1" name="output.voltage" oid=".1.3.6.1.4.1.935.1.1.1.4.2.1.0"/>
+		<snmp_info flag_ok="yes" int_val="yes" multiplier="0.1" name="output.frequency" oid=".1.3.6.1.4.1.935.1.1.1.4.2.2.0"/>
+		<snmp_info flag_ok="yes" int_val="yes" multiplier="1.0" name="ups.load" oid=".1.3.6.1.4.1.935.1.1.1.4.2.3.0"/>
 	</snmp>
 	<mib2nut mib_name="xppc" name="xppc" oid=".1.3.6.1.4.1.935" snmp_info="xppc_mib" version="0.2"/>
 </nut>

--- a/scripts/DMF/jsonify-mib.py.in
+++ b/scripts/DMF/jsonify-mib.py.in
@@ -47,7 +47,7 @@ def debug (msg):
 
 def f2f(node):
     """convert c_ast node flags to list of numbers
-    (1, 2, 4, 8, 4194304) == SU_FLAG_OK | SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_STALE | SU_FLAG_SEMI_STATIC
+    e.g. (1, 2, 4, 8, 512) == SU_FLAG_OK | SU_FLAG_STATIC | SU_FLAG_ABSENT | SU_FLAG_STALE | SU_FLAG_SEMI_STATIC
     """
     if  isinstance (node, c_ast.BinaryOp) and \
         node.op == "<<":

--- a/scripts/DMF/xmlify-mib.py.in
+++ b/scripts/DMF/xmlify-mib.py.in
@@ -204,32 +204,38 @@ def mk_snmp (inp, root):
 
             ### process flags
             for name, flag, value in (
-                    ("flag_ok", SU_FLAG_OK, "yes"),
-                    ("static", SU_FLAG_STATIC, "yes"),
-                    ("semistatic", SU_FLAG_SEMI_STATIC, "yes"),
-                    ("absent", SU_FLAG_ABSENT, "yes"),
-                    ("stale", SU_FLAG_STALE, "yes"),
-                    ("positive", SU_FLAG_NEGINVALID, "yes"),
-                    ("unique", SU_FLAG_UNIQUE, "yes"),
-                    ("power_status", SU_STATUS_PWR, "yes"),
-                    ("battery_status", SU_STATUS_BATT, "yes"),
-                    ("calibration", SU_STATUS_CAL, "yes"),
-                    ("replace_battery", SU_STATUS_RB, "yes"),
-                    ("command", SU_TYPE_CMD, "yes"),
-                    ("outlet_group", SU_OUTLET_GROUP, "yes"),
-                    ("outlet", SU_OUTLET, "yes"),
-                    ("ambient", SU_AMBIENT_TEMPLATE, "yes"),
-                    ("output_1_phase", SU_OUTPUT_1, "yes"),
-                    ("output_3_phase", SU_OUTPUT_3, "yes"),
-                    ("input_1_phase", SU_INPUT_1, "yes"),
-                    ("input_3_phase", SU_INPUT_3, "yes"),
-                    ("bypass_1_phase", SU_BYPASS_1, "yes"),
-                    ("bypass_3_phase", SU_BYPASS_3, "yes"),
-                    ("type_daisy", SU_TYPE_DAISY_1, "1"),
-                    ("type_daisy", SU_TYPE_DAISY_2, "2"),
-                    ("type_daisy", SU_TYPE_DAISY_MASTER_ONLY, "3"),
-                    ("zero_invalid", SU_FLAG_ZEROINVALID, "yes"),
-                    ("na_invalid", SU_FLAG_NAINVALID, "yes"),
+                    ("flag_ok", SU_FLAG_OK, "yes"),                 # (1 << 0)
+                    ("static", SU_FLAG_STATIC, "yes"),              # (1 << 1)
+                    ("absent", SU_FLAG_ABSENT, "yes"),              # (1 << 2)
+                    ("stale", SU_FLAG_STALE, "yes"),                # (1 << 3)
+                    ("positive", SU_FLAG_NEGINVALID, "yes"),        # (1 << 4)
+                    ("unique", SU_FLAG_UNIQUE, "yes"),              # (1 << 5)
+                    ("zero_invalid", SU_FLAG_ZEROINVALID, "yes"),   # (1 << 6)
+                    ("na_invalid", SU_FLAG_NAINVALID, "yes"),       # (1 << 7)
+                    ("command_offset", SU_CMD_OFFSET, "yes"),       # (1 << 8)
+                    ("semistatic", SU_FLAG_SEMI_STATIC, "yes"),     # (1 << 9)
+                    ("outlet_group", SU_OUTLET_GROUP, "yes"),       # (1 << 10)
+                    ("outlet", SU_OUTLET, "yes"),                   # (1 << 11)
+                    ("input_1_phase", SU_INPUT_1, "yes"),           # (1 << 12)
+                    ("input_3_phase", SU_INPUT_3, "yes"),           # (1 << 13)
+                    ("output_1_phase", SU_OUTPUT_1, "yes"),         # (1 << 14)
+                    ("output_3_phase", SU_OUTPUT_3, "yes"),         # (1 << 15)
+                    ("bypass_1_phase", SU_BYPASS_1, "yes"),         # (1 << 16)
+                    ("bypass_3_phase", SU_BYPASS_3, "yes"),         # (1 << 17)
+                    ("int_val", SU_TYPE_INT, "yes"),                # (1 << 18) #/* cast to int when setting value */
+                    ("time_val", SU_TYPE_TIME, "yes"),              # (1 << 19)
+                    ("command", SU_TYPE_CMD, "yes"),                # (1 << 20)
+                    ("type_daisy", SU_TYPE_DAISY_1, "1"),           # (1 << 21)
+                    ("type_daisy", SU_TYPE_DAISY_2, "2"),           # (1 << 22)
+                                                    #???# SU_DAISY  # (1 << 23)
+                    ("type_daisy", SU_TYPE_DAISY_MASTER_ONLY, "3"), # (1 << 24)
+                                                    # NOT USED YET  # (1 << 25)
+                    ("ambient", SU_AMBIENT_TEMPLATE, "yes"),        # (1 << 26)
+                    # Should not be set by MIB2NUT mappings: SU_FLAG_FUNCTION # (1 << 27)
+                    ("power_status", SU_STATUS_PWR, "yes"),         # (1 << 28)
+                    ("battery_status", SU_STATUS_BATT, "yes"),      # (1 << 29)
+                    ("calibration", SU_STATUS_CAL, "yes"),          # (1 << 30)
+                    ("replace_battery", SU_STATUS_RB, "yes"),       # (1 << 31)
                     ):
                 if not flag in info ["flags"]:
                     continue

--- a/scripts/DMF/xmlify-mib.py.in
+++ b/scripts/DMF/xmlify-mib.py.in
@@ -25,50 +25,68 @@ ST_FLAG_STRING = 0x0002
 ST_FLAG_IMMUTABLE = 0x0004
 
 # snmp-ups.h
-SU_FLAG_OK = (1 << 0)		#/* show element to upsd - internal to snmp driver */
-SU_FLAG_STATIC = (1 << 1)	#/* retrieve info only once. */
-SU_FLAG_ABSENT = (1 << 2)	#/* data is absent in the device,
+SU_FLAG_OK =           (1 << 0)	#/* show element to upsd - internal to snmp driver */
+SU_FLAG_STATIC =       (1 << 1)	#/* retrieve info only once. */
+SU_FLAG_ABSENT =       (1 << 2)	#/* data is absent in the device,
 				# * use default value. */
-SU_FLAG_STALE = (1 << 3)	#/* data stale, don't try too often - internal to snmp driver */
-SU_FLAG_NEGINVALID = (1 << 4)	#/* Invalid if negative value */
-SU_FLAG_UNIQUE = (1 << 5)	#/* There can be only be one
+SU_FLAG_STALE =        (1 << 3)	#/* data stale, don't try too often - internal to snmp driver */
+SU_FLAG_NEGINVALID =   (1 << 4)	#/* Invalid if negative value */
+SU_FLAG_UNIQUE =       (1 << 5)	#/* There can be only be one
 				# * provider of this info,
 				# * disable the other providers */
-SU_AMBIENT_TEMPLATE = (1 << 6)	#/* ambient template definition */
-SU_OUTLET = (1 << 7)	        #/* outlet template definition */
-SU_CMD_OFFSET = (1 << 8)	#/* Add +1 to the OID index */
+SU_FLAG_ZEROINVALID =  (1 << 6)	#/* Invalid if "0" value */
+SU_FLAG_NAINVALID =    (1 << 7)	#/* Invalid if "N/A" value */
+SU_CMD_OFFSET =        (1 << 8)	#/* Add +1 to the OID index */
 
-SU_STATUS_PWR = (0 << 8)	#/* indicates power status element */
-SU_STATUS_BATT = (1 << 8)	#/* indicates battery status element */
-SU_STATUS_CAL = (2 << 8)	#/* indicates calibration status element */
-SU_STATUS_RB = (3 << 8)		#/* indicates replace battery status element */
-SU_STATUS_NUM_ELEM = 4
-SU_OUTLET_GROUP = (1 << 10)	#/* outlet group template definition */
+SU_FLAG_SEMI_STATIC =  (1 << 9)	#/* retrieve info every few update walks. */
+
+#/* Notes on outlet templates usage:
+# * - outlet.count MUST exist and MUST be declared before any outlet template
+# * Otherwise, the driver will try to determine it by itself...
+# * - the first outlet template MUST NOT be a server side variable (ie MUST have
+# *   a valid OID) in order to detect the base SNMP index (0 or 1)
+# */
+SU_OUTLET_GROUP =      (1 << 10)	#/* outlet group template definition */
+SU_OUTLET =            (1 << 11)	#/* outlet template definition */
 
 #/* Phase specific data */
-SU_PHASES = (0x3F << 12)
-SU_INPHASES = (0x3 << 12)
-SU_INPUT_1 = (1 << 12)		#/* only if 1 input phase */
-SU_INPUT_3 = (1 << 13)		#/* only if 3 input phases */
-SU_OUTPHASES = (0x3 << 14)
-SU_OUTPUT_1 = (1 << 14)		#/* only if 1 output phase */
-SU_OUTPUT_3 = (1 << 15)		#/* only if 3 output phases */
-SU_BYPPHASES = (0x3 << 16)
-SU_BYPASS_1 = (1 << 16)		#/* only if 1 bypass phase */
-SU_BYPASS_3 = (1 << 17)		#/* only if 3 bypass phases */
+SU_PHASES =         (0x3F << 12)
+SU_INPHASES =       (0x03 << 12)
+SU_INPUT_1 =           (1 << 12)	#/* only if 1 input phase */
+SU_INPUT_3 =           (1 << 13)	#/* only if 3 input phases */
+SU_OUTPHASES =      (0x03 << 14)
+SU_OUTPUT_1 =          (1 << 14)	#/* only if 1 output phase */
+SU_OUTPUT_3 =          (1 << 15)	#/* only if 3 output phases */
+SU_BYPPHASES =      (0x03 << 16)
+SU_BYPASS_1 =          (1 << 16)	#/* only if 1 bypass phase */
+SU_BYPASS_3 =          (1 << 17)	#/* only if 3 bypass phases */
 
 #/* hints for su_ups_set, applicable only to rw vars */
-SU_TYPE_INT = (0 << 18)		#/* cast to int when setting value */
-SU_TYPE_STRING = (1 << 18)	#/* cast to string. FIXME: redundant with ST_FLAG_STRING */
-SU_TYPE_TIME = (2 << 18)	#/* cast to int */
-SU_TYPE_CMD = (3 << 18)		#/* instant command */
-SU_TYPE_DAISY_1 = (1 << 19)
-SU_TYPE_DAISY_2 = (2 << 19)
-SU_FLAG_ZEROINVALID = (1 << 20)	#/* Invalid if "0" value */
-SU_FLAG_NAINVALID = (1 << 21)	#/* Invalid if "N/A" value */
+SU_TYPE_INT =          (1 << 18)	#/* cast to int when setting value */
+SU_TYPE_TIME =         (1 << 19)	#/* cast to int */
+SU_TYPE_CMD =          (1 << 20)	#/* instant command */
 
-SU_FLAG_SEMI_STATIC = (1 << 22)	#/* retrieve info every few update walks. */
-SU_TYPE_DAISY_MASTER_ONLY = (1 << 23) #/* Only valid for daisychain master (device.1) */
+#/* Daisychain template definition */
+#/* the following 2 flags specify the position of the daisychain device index
+# * in the formatting string. This is useful when considering daisychain with
+# * templates, such as outlets / outlets groups, which already have a format
+# * string specifier */
+SU_TYPE_DAISY_1 =      (1 << 21)	#/* Daisychain index is the 1st specifier */
+SU_TYPE_DAISY_2 =      (1 << 22)	#/* Daisychain index is the 2nd specifier */
+SU_DAISY =             (1 << 23)	#/* Daisychain template definition */
+SU_TYPE_DAISY_MASTER_ONLY = (1 << 24) #/* Only valid for daisychain master (device.1) */
+
+#/* no (1 << 25) yet */
+
+SU_AMBIENT_TEMPLATE =  (1 << 26)	#/* ambient template definition */
+
+SU_FLAG_FUNCTION =     (1 << 27)	#/* #if WITH_DMF_FUNCTIONS */
+
+SU_STATUS_PWR =        (1 << 28)	#/* indicates power status element */
+SU_STATUS_BATT =       (1 << 29)	#/* indicates battery status element */
+SU_STATUS_CAL =        (1 << 30)	#/* indicates calibration status element */
+SU_STATUS_RB =         (1 << 31)	#/* indicates replace battery status element */
+SU_STATUS_NUM_ELEM = 4
 
 def die (msg):
     print ("E: " + msg, file=sys.stderr)
@@ -219,7 +237,7 @@ def mk_snmp (inp, root):
                 info ["flags"].remove (flag)
 
             # ignore flags not relevant to XML generations
-            for flag in (SU_FLAG_OK, SU_TYPE_STRING, SU_TYPE_INT):
+            for flag in (SU_FLAG_OK, SU_TYPE_INT):
                 if flag in info ["flags"]:
                     info ["flags"].remove (flag)
 

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -479,7 +479,13 @@ static void scan_snmp_add_device(nutscan_snmp_t * sec, struct snmp_pdu *response
 #if WITH_DMFMIB
 	dev->driver = NULL;
 	if (dmfnutscan_snmp_dmp != NULL) {
-		/* DMF is loaded thus used, successfully */
+		/* DMF is loaded thus used, successfully (with at least a collection
+		 * of <mib2nut> tags - entries needed for supportability discovery).
+		 */
+		upsdebugx(4, "%s: using MIB '%s' loaded from DMF dir '%s'",
+			__func__, mib ? mib : "null",
+			dmfnutscan_snmp_dir ? dmfnutscan_snmp_dir : "null");
+
 		if (mib && strcmp(mib, "eaton_epdu") == 0) {
 			// FIXME (WITH_SNMP_LKP_FUN): When support for lookup functions
 			// in DMF is fixed, this clause has to be amended back, too.

--- a/tools/nut-scanner/scan_snmp.c
+++ b/tools/nut-scanner/scan_snmp.c
@@ -479,12 +479,54 @@ static void scan_snmp_add_device(nutscan_snmp_t * sec, struct snmp_pdu *response
 #if WITH_DMFMIB
 	dev->driver = NULL;
 	if (dmfnutscan_snmp_dmp != NULL) {
+		size_t mib2nut_count_total = 0;
+		size_t mib2nut_count_useful = 0;
+		bool_t mib2nut_has_data = FALSE;
+
 		/* DMF is loaded thus used, successfully (with at least a collection
 		 * of <mib2nut> tags - entries needed for supportability discovery).
 		 */
 		upsdebugx(4, "%s: using MIB '%s' loaded from DMF dir '%s'",
 			__func__, mib ? mib : "null",
 			dmfnutscan_snmp_dir ? dmfnutscan_snmp_dir : "null");
+
+		/* Check if we have actual data mappings here (is the DMFDIR used
+		 * for scanning a good one to hardcode into driver configuration,
+		 * or just an excerpt with lots of <mib2nut> tags for quicker load
+		 * during nut-scanning?)
+		 */
+		mib2nut_info_t **mib2nut = *(mibdmf_get_mib2nut_table_ptr)(dmfnutscan_snmp_dmp);
+		if (mib2nut == NULL) {
+			upsdebugx(4, "%s: WARNING: Could not access the mib2nut index table",
+				__func__);
+		} else {
+			size_t i;
+			for (i = 0; mib2nut[i] != NULL; i++) {
+				bool_t isUseful = (mib2nut[i]->snmp_info
+					&&  mib2nut[i]->snmp_info[0].info_type != NULL);
+				if (isUseful) mib2nut_count_useful++;
+
+				if (mib && mib2nut[i]->mib_name
+				&&  strcmp(mib, mib2nut[i]->mib_name) == 0
+				) {
+					if (isUseful) {
+						upsdebugx(4, "%s: Have mib2nut data for \"%s\" "
+							"OID mappings",
+							__func__, mib);
+						mib2nut_has_data = true;
+					} else {
+						upsdebugx(4, "%s: Have mib2nut index entry for \"%s\", "
+							"but no data for OID mappings",
+							__func__, mib);
+					}
+				}
+			}
+			mib2nut_count_total = i;
+		}
+		upsdebugx(3, "%s: Inspected the mib2nut index table, "
+			"saw a total of %zu mappings and "
+			"%zu useful for snmp-ups driver",
+			__func__, mib2nut_count_total, mib2nut_count_useful);
 
 		if (mib && strcmp(mib, "eaton_epdu") == 0) {
 			// FIXME (WITH_SNMP_LKP_FUN): When support for lookup functions
@@ -496,9 +538,23 @@ static void scan_snmp_add_device(nutscan_snmp_t * sec, struct snmp_pdu *response
 			upslogx(1, "This device mapping uses lookup functions which is not yet supported by DMF driver");
 		} else {
 			dev->driver = strdup("snmp-ups-dmf");
-			if (dmfnutscan_snmp_dir != NULL && strcmp(DEFAULT_DMFNUTSCAN_DIR, dmfnutscan_snmp_dir) != 0) {
-				nutscan_add_option_to_device(dev, SU_VAR_DMFDIR,
-					dmfnutscan_snmp_dir);
+			/* Actually, DMFNUTSCAN dir is quick for nut-scanner
+			 * but useless for snmp-ups(-dmf) driver
+			 */
+			if (dmfnutscan_snmp_dir != NULL
+			&& (strcmp(DEFAULT_DMFNUTSCAN_DIR, dmfnutscan_snmp_dir) != 0
+			 || strcmp(DEFAULT_DMFSNMP_DIR, dmfnutscan_snmp_dir) != 0)
+			) {
+				/* Using non-default directory */
+				if (mib2nut_has_data) {
+					nutscan_add_option_to_device(dev, SU_VAR_DMFDIR,
+						dmfnutscan_snmp_dir);
+				} else {
+					upslogx(0, "WARNING: This device scan was done with a "
+						"DMF mapping data directory '%s' that did not contain "
+						"complete data useful for the '%s' driver with MIB '%s'",
+						dmfnutscan_snmp_dir, dev->driver, mib);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Sibling to https://github.com/networkupstools/nut/pull/1180 with adaptations for new DMF-related flags and scripts.

Work in progress to see how that impacts build and run-time behavior.