### PR TITLE
Eaton SNMP: also publish ups.load for 3phase

### DIFF
--- a/drivers/powerware-mib.c
+++ b/drivers/powerware-mib.c
@@ -29,7 +29,7 @@
 #include "eaton-pdu-marlin-helpers.h"
 #endif
 
-#define PW_MIB_VERSION "0.99"
+#define PW_MIB_VERSION "1.00"
 
 /* TODO: more sysOID and MIBs support:
  *
@@ -929,7 +929,7 @@ static snmp_info_t pw_mib[] = {
 	{ "ups.serial", ST_FLAG_STRING, SU_INFOSIZE, IETF_OID_IDENT, "",
 		SU_FLAG_STATIC, NULL },
 	{ "ups.load", 0, 1.0, PW_OID_OUT_LOAD, "",
-		SU_OUTPUT_1, NULL },
+		0, NULL },
 	/* FIXME: should be removed in favor of output.power */
 	{ "ups.power", 0, 1.0, PW_OID_OUT_POWER ".1", "",
 		0, NULL },

--- a/scripts/DMF/dmfsnmp/powerware-mib.dmf
+++ b/scripts/DMF/dmfsnmp/powerware-mib.dmf
@@ -173,7 +173,7 @@
 		<snmp_info default="" multiplier="128.0" name="ups.firmware" oid="1.3.6.1.4.1.534.1.1.3.0" power_status="yes" string="yes"/>
 		<snmp_info default="" multiplier="128.0" name="ups.firmware.aux" oid="1.3.6.1.2.1.33.1.1.4.0" power_status="yes" string="yes"/>
 		<snmp_info default="" multiplier="128.0" name="ups.serial" oid="1.3.6.1.2.1.33.1.1.5.0" static="yes" string="yes"/>
-		<snmp_info default="" multiplier="1.0" name="ups.load" oid="1.3.6.1.4.1.534.1.4.1.0" output_1_phase="yes"/>
+		<snmp_info default="" multiplier="1.0" name="ups.load" oid="1.3.6.1.4.1.534.1.4.1.0" power_status="yes"/>
 		<snmp_info default="" multiplier="1.0" name="ups.power" oid="1.3.6.1.4.1.534.1.4.4.1.4.1" power_status="yes"/>
 		<snmp_info default="" multiplier="1.0" name="ups.power" oid="1.3.6.1.4.1.534.1.4.4.1.4.1.0" power_status="yes"/>
 		<snmp_info default="OFF" lookup="pw_pwr_info" multiplier="128.0" name="ups.status" oid="1.3.6.1.4.1.534.1.4.5.0" power_status="yes" string="yes"/>
@@ -302,7 +302,7 @@
 		<snmp_info command="yes" multiplier="1.0" name="outlet.%i.load.on.delay" oid=".1.3.6.1.4.1.534.1.12.2.1.4.%i" outlet="yes"/>
 		<snmp_info default="" multiplier="1.0" name="ups.alarms" oid="1.3.6.1.4.1.534.1.7.1.0" power_status="yes"/>
 	</snmp>
-	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pw" name="powerware" oid=".1.3.6.1.4.1.534.1" snmp_info="pw_mib" version="0.99"/>
-	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pxgx_ups" name="pxgx_ups" oid=".1.3.6.1.4.1.534.2.12" snmp_info="pw_mib" version="0.99"/>
+	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pw" name="powerware" oid=".1.3.6.1.4.1.534.1" snmp_info="pw_mib" version="1.00"/>
+	<mib2nut alarms_info="pw_alarms" auto_check="1.3.6.1.4.1.534.1.1.2.0" mib_name="pxgx_ups" name="pxgx_ups" oid=".1.3.6.1.4.1.534.2.12" snmp_info="pw_mib" version="1.00"/>
 </nut>
 


### PR DESCRIPTION
Though there is output.Lx.power.percent, for 3phase,
it's desirable to also have the standard ups.load

Signed-off-by: Arnaud Quette <ArnaudQuette@eaton.com>